### PR TITLE
v0.3/tier1 foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "atk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241b621213072e993be4f6f3a9e4b45f65b7e6faad43001be957184b7bb1824b"
+dependencies = [
+ "atk-sys",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "atk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e48b684b0ca77d2bbadeef17424c2ea3c897d44d566a1617e7e8f30614d086"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +500,9 @@ name = "bitflags"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block"
@@ -563,6 +589,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cairo-rs"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
+dependencies = [
+ "bitflags 2.10.0",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+ "once_cell",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685c9fa8e590b8b3d678873528d83411db17242a73fccaed827770ea0fedda51"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +681,16 @@ name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
 
 [[package]]
 name = "cfg-if"
@@ -793,6 +854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1147,6 +1217,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset",
+ "rustc_version",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1322,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1301,6 +1392,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "gdk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f245958c627ac99d8e529166f9823fb3b838d1d41fd2b297af3075093c2691"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk-pixbuf"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e1f5f1b0bfb830d6ccc8066d18db35c487b1b2b1e8589b5dfe9f07e8defaec"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9839ea644ed9c97a34d129ad56d38a25e6756f99f3a88e15cd39c20629caf7"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
+name = "gdk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2d13f38594ac1e66619e188c6d5a1adb98d11b2fcf7894fc416ad76aa2f3f7"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1493,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "gio"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fc8f532f87b79cbc51a79748f16a6828fb784be93145a322fa14d06d354c73"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "once_cell",
+ "pin-project-lite",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37566df850baf5e4cb0dfb78af2e4b9898d817ed9263d1090a2df958c64737d2"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+ "winapi",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1533,53 @@ dependencies = [
  "khronos_api",
  "log",
  "xml-rs",
+]
+
+[[package]]
+name = "glib"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
+dependencies = [
+ "bitflags 2.10.0",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb0228f477c0900c880fd78c8759b95c7636dbd7842707f49e132378aa2acdc"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-crate 2.0.2",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.109",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063ce2eb6a8d0ea93d2bf8ba1957e78dbab6be1c2220dd3daca57d5a9d869898"
+dependencies = [
+ "libc",
+ "system-deps",
 ]
 
 [[package]]
@@ -1445,6 +1673,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "gobject-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0850127b514d1c4a4654ead6dedadb18198999985908e6ffe4436f53c785ce44"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "gpu-alloc"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,6 +1736,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "gtk"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56fb197bfc42bd5d2751f4f017d44ff59fbb58140c6b49f9b3b2bdab08506a"
+dependencies = [
+ "atk",
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk",
+ "gdk-pixbuf",
+ "gio",
+ "glib",
+ "gtk-sys",
+ "gtk3-macros",
+ "libc",
+ "pango",
+ "pkg-config",
+]
+
+[[package]]
+name = "gtk-sys"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f29a1c21c59553eb7dd40e918be54dccd60c52b049b75119d5d96ce6b624414"
+dependencies = [
+ "atk-sys",
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "system-deps",
+]
+
+[[package]]
+name = "gtk3-macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ff3c5b21f14f0736fed6dcfc0bfb4225ebf5725f3c0209edeec181e4d73e9d"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.109",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1835,18 @@ dependencies = [
  "widestring",
  "winapi",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1795,7 +2098,7 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
- "png",
+ "png 0.18.0",
 ]
 
 [[package]]
@@ -1882,6 +2185,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyboard-types"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
+dependencies = [
+ "bitflags 2.10.0",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,6 +2237,25 @@ dependencies = [
  "bitflags 2.10.0",
  "libc",
  "redox_syscall 0.5.18",
+]
+
+[[package]]
+name = "libxdo"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00333b8756a3d28e78def82067a377de7fa61b24909000aeaa2b446a948d14db"
+dependencies = [
+ "libxdo-sys",
+]
+
+[[package]]
+name = "libxdo-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23b9e7e2b7831bbd8aac0bbeeeb7b68cbebc162b227e7052e8e55829a09212"
+dependencies = [
+ "libc",
+ "x11",
 ]
 
 [[package]]
@@ -2060,6 +2393,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "muda"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdae9c00e61cc0579bcac625e8ad22104c60548a025bfc972dc83868a28e1484"
+dependencies = [
+ "crossbeam-channel",
+ "dpi",
+ "gtk",
+ "keyboard-types",
+ "libxdo",
+ "objc2 0.5.2",
+ "objc2-app-kit 0.2.2",
+ "objc2-foundation 0.2.2",
+ "once_cell",
+ "png 0.17.16",
+ "thiserror 1.0.69",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "naga"
 version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2180,7 +2533,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.109",
@@ -2552,6 +2905,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pango"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ca27ec1eb0457ab26f3036ea52229edbdb74dee1edd29063f5b9b010e7ebee4"
+dependencies = [
+ "gio",
+ "glib",
+ "libc",
+ "once_cell",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436737e391a843e5933d6d9aa102cb126d501e815b83601365a948a518555dc5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,6 +3021,19 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "png"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
@@ -2710,11 +3101,55 @@ checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
+dependencies = [
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "proc-macro-crate"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.23.7",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -2969,6 +3404,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,6 +3486,7 @@ dependencies = [
  "eframe",
  "egui",
  "image",
+ "muda",
  "objc",
  "poll-promise",
  "reqwest",
@@ -3126,6 +3571,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3177,6 +3628,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.109",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3436,6 +3896,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3594,6 +4073,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "185d8ab0dfbb35cf1399a6344d8484209c088f75f8f68230da55d48d95d43e3d"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.3",
+ "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3604,14 +4104,38 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime 0.6.3",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 0.7.3",
  "toml_parser",
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -3620,7 +4144,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
- "winnow",
+ "winnow 0.7.13",
 ]
 
 [[package]]
@@ -3821,6 +4345,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -4704,6 +5234,15 @@ dependencies = [
 
 [[package]]
 name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
@@ -4722,6 +5261,16 @@ name = "writeable"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x11"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502da5464ccd04011667b11c435cb992822c2c0dbde1770c988480d312a0db2e"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "x11-dl"
@@ -4886,7 +5435,7 @@ dependencies = [
  "uds_windows",
  "uuid",
  "windows-sys 0.61.2",
- "winnow",
+ "winnow 0.7.13",
  "zbus_macros 5.14.0",
  "zbus_names 4.3.1",
  "zvariant 5.10.0",
@@ -4922,7 +5471,7 @@ version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.109",
@@ -4935,7 +5484,7 @@ version = "5.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.109",
@@ -4962,7 +5511,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.13",
  "zvariant 5.10.0",
 ]
 
@@ -5082,7 +5631,7 @@ dependencies = [
  "enumflags2",
  "serde",
  "url",
- "winnow",
+ "winnow 0.7.13",
  "zvariant_derive 5.10.0",
  "zvariant_utils 3.3.0",
 ]
@@ -5093,7 +5642,7 @@ version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.109",
@@ -5106,7 +5655,7 @@ version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
 dependencies = [
- "proc-macro-crate",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.109",
@@ -5134,5 +5683,5 @@ dependencies = [
  "quote",
  "serde",
  "syn 2.0.109",
- "winnow",
+ "winnow 0.7.13",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"
+# Native NSMenu-backed menu bar — drops a system menu on the top of
+# the screen (the macOS-idiomatic place) instead of rendering one
+# inside the window. Linux keeps the in-window egui menu bar.
+muda = "0.15"
 
 [profile.release]
 opt-level = "z"

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ bundle-mac: $(RELEASE_BIN) $(ICON_PNG)
 	  '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' \
 	  '<plist version="1.0">' \
 	  '<dict>' \
-	  '  <key>CFBundleName</key><string>$(APP_NAME)</string>' \
+	  '  <key>CFBundleName</key><string>Rusty Requester</string>' \
 	  '  <key>CFBundleDisplayName</key><string>Rusty Requester</string>' \
 	  '  <key>CFBundleIdentifier</key><string>$(BUNDLE_ID)</string>' \
 	  '  <key>CFBundleVersion</key><string>$(VERSION)</string>' \

--- a/src/macos_menu.rs
+++ b/src/macos_menu.rs
@@ -1,0 +1,172 @@
+//! Native macOS `NSMenu` bar — built via the `muda` crate so the menu
+//! lives on the top of the screen (the macOS-idiomatic place) instead
+//! of inside the window. Item IDs are stable strings that `ApiClient`
+//! checks each frame via `poll_menu_events`.
+//!
+//! Linux/Windows don't go through this module — they keep the in-window
+//! egui menu bar in `ui::modals::render_menu_bar`.
+
+use muda::{
+    accelerator::{Accelerator, Code, Modifiers},
+    Menu, MenuItem, PredefinedMenuItem, Submenu,
+};
+
+pub const MENU_NEW_REQUEST: &str = "new_request";
+pub const MENU_NEW_COLLECTION: &str = "new_collection";
+pub const MENU_IMPORT: &str = "import";
+pub const MENU_PASTE_CURL: &str = "paste_curl";
+pub const MENU_EXPORT_JSON: &str = "export_json";
+pub const MENU_EXPORT_YAML: &str = "export_yaml";
+pub const MENU_TOGGLE_SNIPPET: &str = "toggle_snippet";
+pub const MENU_SEND: &str = "send";
+pub const MENU_SETTINGS: &str = "settings";
+pub const MENU_ENVIRONMENTS: &str = "environments";
+pub const MENU_ABOUT: &str = "about";
+pub const MENU_GITHUB: &str = "github";
+pub const MENU_REPORT_ISSUE: &str = "report_issue";
+
+/// Install a system NSMenu bar on `NSApp`. Must be called after
+/// `set_macos_activation_policy_regular()` has run (otherwise NSApp
+/// is in accessory mode and the menu bar is hidden).
+///
+/// The `Menu` value must be kept alive for the life of the app; we
+/// leak it on purpose via `Box::leak` so callers don't need to store
+/// it (no state-plumbing into `ApiClient`).
+pub fn install() {
+    let cmd = Modifiers::META; // Command on macOS
+    let shift = Modifiers::META.union(Modifiers::SHIFT);
+
+    let menu = Menu::new();
+
+    // --- App menu (the leftmost one, named after the app) ---------------
+    //
+    // The About entry's title starts with a zero-width space
+    // (`\u{200B}`) so users see "About Rusty Requester" visually
+    // while muda/AppKit's prefix check for `"About "` doesn't match
+    // — otherwise the item gets auto-routed to NSApp's stock
+    // `orderFrontStandardAboutPanel:` and our custom modal never
+    // opens. Apple HIG wants the About item at the top of the app
+    // menu; the zero-width-space hack is how we keep it there AND
+    // keep our own handler firing.
+    let app_submenu = Submenu::new("Rusty Requester", true);
+    app_submenu
+        .append_items(&[
+            &MenuItem::with_id(
+                MENU_ABOUT,
+                "\u{200B}About Rusty Requester",
+                true,
+                None,
+            ),
+            &PredefinedMenuItem::separator(),
+            &MenuItem::with_id(
+                MENU_SETTINGS,
+                "Preferences…",
+                true,
+                Some(Accelerator::new(Some(cmd), Code::Comma)),
+            ),
+            &PredefinedMenuItem::separator(),
+            &PredefinedMenuItem::hide(None),
+            &PredefinedMenuItem::hide_others(None),
+            &PredefinedMenuItem::show_all(None),
+            &PredefinedMenuItem::separator(),
+            &PredefinedMenuItem::quit(None),
+        ])
+        .unwrap();
+
+    // --- File -----------------------------------------------------------
+    let file = Submenu::new("File", true);
+    file.append_items(&[
+        &MenuItem::with_id(
+            MENU_NEW_REQUEST,
+            "New Request",
+            true,
+            Some(Accelerator::new(Some(cmd), Code::KeyT)),
+        ),
+        &MenuItem::with_id(MENU_NEW_COLLECTION, "New Collection", true, None),
+        &PredefinedMenuItem::separator(),
+        &MenuItem::with_id(
+            MENU_IMPORT,
+            "Import collection file…",
+            true,
+            Some(Accelerator::new(Some(cmd), Code::KeyO)),
+        ),
+        &MenuItem::with_id(MENU_PASTE_CURL, "Paste cURL command…", true, None),
+        &PredefinedMenuItem::separator(),
+        &MenuItem::with_id(MENU_EXPORT_JSON, "Export all as JSON…", true, None),
+        &MenuItem::with_id(MENU_EXPORT_YAML, "Export all as YAML…", true, None),
+    ])
+    .unwrap();
+
+    // --- Edit (standard first-responder actions) ------------------------
+    let edit = Submenu::new("Edit", true);
+    edit.append_items(&[
+        &PredefinedMenuItem::undo(None),
+        &PredefinedMenuItem::redo(None),
+        &PredefinedMenuItem::separator(),
+        &PredefinedMenuItem::cut(None),
+        &PredefinedMenuItem::copy(None),
+        &PredefinedMenuItem::paste(None),
+        &PredefinedMenuItem::select_all(None),
+    ])
+    .unwrap();
+
+    // --- View ----------------------------------------------------------
+    let view = Submenu::new("View", true);
+    view.append_items(&[
+        &MenuItem::with_id(
+            MENU_TOGGLE_SNIPPET,
+            "Toggle code snippet panel",
+            true,
+            Some(Accelerator::new(Some(shift), Code::KeyC)),
+        ),
+    ])
+    .unwrap();
+
+    // --- Request -------------------------------------------------------
+    let request = Submenu::new("Request", true);
+    request
+        .append_items(&[
+            &MenuItem::with_id(
+                MENU_SEND,
+                "Send",
+                true,
+                Some(Accelerator::new(Some(cmd), Code::Enter)),
+            ),
+            &PredefinedMenuItem::separator(),
+            &MenuItem::with_id(MENU_ENVIRONMENTS, "Environments…", true, None),
+        ])
+        .unwrap();
+
+    // --- Help ----------------------------------------------------------
+    //
+    // About item uses the same zero-width-space-prefixed title as
+    // the app menu's About so AppKit's auto-router can't hijack it
+    // either.
+    let help = Submenu::new("Help", true);
+    help.append_items(&[
+        &MenuItem::with_id(MENU_ABOUT, "\u{200B}About Rusty Requester", true, None),
+        &PredefinedMenuItem::separator(),
+        &MenuItem::with_id(MENU_GITHUB, "Open GitHub repo", true, None),
+        &MenuItem::with_id(MENU_REPORT_ISSUE, "Report an issue", true, None),
+    ])
+    .unwrap();
+
+    menu.append_items(&[&app_submenu, &file, &edit, &view, &request, &help])
+        .unwrap();
+
+    menu.init_for_nsapp();
+
+    // Keep the menu alive forever — NSApp holds a raw pointer to its
+    // items, so dropping this would invalidate them.
+    Box::leak(Box::new(menu));
+}
+
+/// Drain any menu events emitted since the last call. Returns a list
+/// of item IDs the user activated. Safe to call every frame.
+pub fn drain_events() -> Vec<String> {
+    let mut out = Vec::new();
+    while let Ok(ev) = muda::MenuEvent::receiver().try_recv() {
+        out.push(ev.id().0.clone());
+    }
+    out
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,8 @@
 mod extract;
 mod icon;
 mod io;
+#[cfg(target_os = "macos")]
+mod macos_menu;
 mod model;
 mod net;
 mod snippet;
@@ -144,6 +146,14 @@ struct ApiClient {
     /// Working copy of settings while the modal is open. Committed to
     /// `state.settings` on Save.
     editing_settings: AppSettings,
+    /// About modal (Help → About Rusty Requester).
+    show_about_modal: bool,
+    /// Have we installed the macOS NSMenu yet? We defer the install
+    /// to the first `update()` frame because doing it before
+    /// `eframe::run_native` lets winit overwrite our menu with its
+    /// default Services/Hide/Quit stub.
+    #[cfg(target_os = "macos")]
+    macos_menu_installed: bool,
 }
 
 impl Default for ApiClient {
@@ -237,6 +247,9 @@ impl Default for ApiClient {
             http_client: net::build_client(&AppSettings::default()),
             show_settings_modal: false,
             editing_settings: AppSettings::default(),
+            show_about_modal: false,
+            #[cfg(target_os = "macos")]
+            macos_menu_installed: false,
         };
         // Rebuild the HTTP client from the deserialized settings — the
         // initial one above was a placeholder, because we couldn't read
@@ -746,8 +759,89 @@ impl ApiClient {
 
 
 
+#[cfg(target_os = "macos")]
+impl ApiClient {
+    /// Drain macOS NSMenu events and map each item ID to an action.
+    fn dispatch_macos_menu_events(&mut self) {
+        use macos_menu as m;
+        for id in m::drain_events() {
+            match id.as_str() {
+                m::MENU_NEW_REQUEST => self.new_draft_request(),
+                m::MENU_NEW_COLLECTION => {
+                    self.state.folders.push(Folder {
+                        id: Uuid::new_v4().to_string(),
+                        name: format!("Collection {}", self.state.folders.len() + 1),
+                        requests: vec![],
+                        subfolders: vec![],
+                    });
+                    self.save_state();
+                }
+                m::MENU_IMPORT => self.pending_import = true,
+                m::MENU_PASTE_CURL => {
+                    self.show_paste_modal = true;
+                    self.paste_curl_text.clear();
+                    self.paste_error.clear();
+                }
+                m::MENU_EXPORT_JSON => self.pending_export_json = true,
+                m::MENU_EXPORT_YAML => self.pending_export_yaml = true,
+                m::MENU_TOGGLE_SNIPPET => self.show_snippet_panel = !self.show_snippet_panel,
+                m::MENU_SEND => self.send_request(),
+                m::MENU_SETTINGS => {
+                    self.editing_settings = self.state.settings.clone();
+                    self.show_settings_modal = true;
+                }
+                m::MENU_ENVIRONMENTS => {
+                    self.show_env_modal = true;
+                    if self.selected_env_for_edit.is_none() {
+                        self.selected_env_for_edit =
+                            self.state.environments.first().map(|e| e.id.clone());
+                    }
+                }
+                m::MENU_ABOUT => {
+                    eprintln!("[menu] MENU_ABOUT fired — opening custom About modal");
+                    self.show_about_modal = true;
+                }
+                m::MENU_GITHUB | m::MENU_REPORT_ISSUE => {
+                    let url = if id == m::MENU_GITHUB {
+                        "https://github.com/chud-lori/rusty-requester"
+                    } else {
+                        "https://github.com/chud-lori/rusty-requester/issues"
+                    };
+                    if let Err(e) = webbrowser_open(url) {
+                        eprintln!("[menu] open url failed: {}", e);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn webbrowser_open(url: &str) -> Result<(), std::io::Error> {
+    // Use `open` — ships with every macOS install; avoids adding a
+    // webbrowser crate just for two menu items.
+    std::process::Command::new("open").arg(url).spawn().map(|_| ())
+}
+
 impl eframe::App for ApiClient {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Install the macOS menu bar on the first frame (after winit
+        // has wired up NSApp). See `macos_menu_installed` doc comment
+        // for why this can't run in `main()`.
+        #[cfg(target_os = "macos")]
+        if !self.macos_menu_installed {
+            self.macos_menu_installed = true;
+            macos_menu::install();
+            eprintln!("[menu] macOS NSMenu installed from first update()");
+        }
+
+        // Dispatch any macOS system-menu selections made since the last
+        // frame. On Linux/Windows this is a no-op — the menu lives in
+        // a `TopBottomPanel` inside the window instead.
+        #[cfg(target_os = "macos")]
+        self.dispatch_macos_menu_events();
+
         // Handle deferred file-dialog actions from the previous frame.
         // These would otherwise block the main thread before the menu
         // popup that triggered them had a chance to close.
@@ -876,6 +970,11 @@ impl eframe::App for ApiClient {
             );
         }
 
+        // On macOS the menu lives in the system menu bar (installed
+        // via `macos_menu::install`). On other platforms we render an
+        // in-window bar across the top.
+        #[cfg(not(target_os = "macos"))]
+        self.render_menu_bar(ctx);
         self.render_sidebar(ctx);
         self.render_snippet_panel(ctx);
         self.render_central(ctx);
@@ -883,6 +982,7 @@ impl eframe::App for ApiClient {
         self.render_env_modal(ctx);
         self.render_settings_modal(ctx);
         self.render_save_draft_modal(ctx);
+        self.render_about_modal(ctx);
         self.render_toast(ctx);
     }
 }
@@ -989,6 +1089,22 @@ fn main() -> Result<(), eframe::Error> {
     if let Err(e) = set_macos_activation_policy_regular() {
         eprintln!("[icon] activation policy set failed: {}", e);
     }
+
+    // Set NSApp's applicationIconImage BEFORE the menu bar is
+    // installed (and before the first About menu click). NSApp's stock
+    // About panel reads this property at render time; if we delay it
+    // until the first `update()` frame, the initial panel shows the
+    // generic file-bundle icon.
+    #[cfg(target_os = "macos")]
+    if let Err(e) = set_macos_app_icon_image(APP_ICON_BYTES) {
+        eprintln!("[icon] early app-icon set failed: {}", e);
+    }
+
+    // The macOS menu bar is installed from the first `update()` frame,
+    // NOT here — winit's NSApp delegate overwrites any menu we set up
+    // before `eframe::run_native` starts its run loop, which is why
+    // you'd see the default Services/Hide/Quit stub instead of our
+    // custom menu bar.
 
     let mut viewport = egui::ViewportBuilder::default()
         .with_inner_size([1280.0, 820.0])

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,17 @@ struct ApiClient {
     /// Whether the inline search input is visible (toggled by the 🔍
     /// icon button in the body toolbar).
     body_search_visible: bool,
+
+    /// Long-lived HTTP client built from `state.settings`. Rebuilt on
+    /// app startup and whenever the Settings modal saves. Reused across
+    /// every send so we don't reopen TCP/TLS pools per request.
+    http_client: reqwest::Client,
+
+    /// Settings modal state.
+    show_settings_modal: bool,
+    /// Working copy of settings while the modal is open. Committed to
+    /// `state.settings` on Save.
+    editing_settings: AppSettings,
 }
 
 impl Default for ApiClient {
@@ -155,6 +166,7 @@ impl Default for ApiClient {
             drafts: vec![],
             open_tabs: vec![],
             active_tab_id: None,
+            settings: AppSettings::default(),
         });
 
         let mut this = Self {
@@ -222,7 +234,14 @@ impl Default for ApiClient {
             body_tree_filter: String::new(),
             body_search_query: String::new(),
             body_search_visible: false,
+            http_client: net::build_client(&AppSettings::default()),
+            show_settings_modal: false,
+            editing_settings: AppSettings::default(),
         };
+        // Rebuild the HTTP client from the deserialized settings — the
+        // initial one above was a placeholder, because we couldn't read
+        // `state.settings` before `state` was moved into `this`.
+        this.http_client = net::build_client(&this.state.settings);
         // Restore active tab — if state has a saved `active_tab_id`,
         // activate that tab now. Otherwise fall back to the first open tab.
         let active_tab: Option<OpenTab> = {
@@ -350,8 +369,11 @@ impl ApiClient {
             self.response_status = "Sending request...".to_string();
             self.response_time = String::new();
             self.response_headers.clear();
+            let client = self.http_client.clone();
+            let max_body_bytes =
+                (self.state.settings.max_body_mb as usize).saturating_mul(1024 * 1024);
             self.request_promise = Some(Promise::spawn_thread("request", move || {
-                net::execute_request(&request, env.as_ref())
+                net::execute_request(client, &request, env.as_ref(), max_body_bytes)
             }));
         }
     }
@@ -859,6 +881,7 @@ impl eframe::App for ApiClient {
         self.render_central(ctx);
         self.render_paste_modal(ctx);
         self.render_env_modal(ctx);
+        self.render_settings_modal(ctx);
         self.render_save_draft_modal(ctx);
         self.render_toast(ctx);
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -232,6 +232,53 @@ pub struct AppState {
     /// `request_id` of the tab that was active at save time.
     #[serde(default)]
     pub active_tab_id: Option<String>,
+    /// App-wide settings: timeout, body cap, proxy, TLS verification.
+    /// Exposed via the Settings modal in the sidebar.
+    #[serde(default)]
+    pub settings: AppSettings,
+}
+
+/// User-configurable networking / safety knobs. Defaults are tuned so
+/// first-time users never need to open the Settings modal.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct AppSettings {
+    /// Per-request timeout in seconds. `0` disables the timeout.
+    #[serde(default = "default_timeout_sec")]
+    pub timeout_sec: u64,
+    /// Max response body size in megabytes. Bytes past this are
+    /// discarded and a banner is shown. `0` disables the cap.
+    #[serde(default = "default_max_body_mb")]
+    pub max_body_mb: u64,
+    /// When false, the HTTPS client accepts self-signed / expired
+    /// certificates. Useful for internal dev APIs; dangerous on the
+    /// public internet.
+    #[serde(default = "default_verify_tls")]
+    pub verify_tls: bool,
+    /// HTTP/HTTPS/SOCKS5 proxy URL (e.g. `http://proxy:8080`). Empty
+    /// = direct.
+    #[serde(default)]
+    pub proxy_url: String,
+}
+
+fn default_timeout_sec() -> u64 {
+    60
+}
+fn default_max_body_mb() -> u64 {
+    50
+}
+fn default_verify_tls() -> bool {
+    true
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            timeout_sec: default_timeout_sec(),
+            max_body_mb: default_max_body_mb(),
+            verify_tls: default_verify_tls(),
+            proxy_url: String::new(),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,11 +1,32 @@
-//! Network layer — HTTP request execution, URL normalization, and
-//! error formatting. Kept free of UI concerns so it can be unit-tested
-//! independently of egui.
+//! Network layer — HTTP request execution, URL normalization, client
+//! construction, and error formatting. Kept free of UI concerns so it
+//! can be unit-tested independently of egui.
 
 use crate::io::curl;
-use crate::model::{Auth, BodyExt, Environment, HttpMethod, Request, ResponseData};
+use crate::model::{AppSettings, Auth, BodyExt, Environment, HttpMethod, Request, ResponseData};
 use crate::widgets::{substitute_kvs, substitute_vars};
 use base64::Engine;
+use std::time::Duration;
+
+/// Build a `reqwest::Client` from the current app settings. Called at
+/// startup and whenever the user tweaks the Settings modal — never per
+/// request.
+pub fn build_client(settings: &AppSettings) -> reqwest::Client {
+    let mut b = reqwest::Client::builder();
+    if settings.timeout_sec > 0 {
+        b = b.timeout(Duration::from_secs(settings.timeout_sec));
+    }
+    if !settings.verify_tls {
+        b = b.danger_accept_invalid_certs(true);
+    }
+    let proxy = settings.proxy_url.trim();
+    if !proxy.is_empty() {
+        if let Ok(p) = reqwest::Proxy::all(proxy) {
+            b = b.proxy(p);
+        }
+    }
+    b.build().unwrap_or_else(|_| reqwest::Client::new())
+}
 
 /// Ensure the URL has a scheme so reqwest can parse it. Defaults to
 /// `http://` — matches curl's historical default and Postman's
@@ -42,11 +63,21 @@ pub fn format_request_error(err: &reqwest::Error) -> String {
     msg
 }
 
-/// Fire a single HTTP request (synchronously; spawns its own tokio
-/// runtime per call) and return a fully-populated `ResponseData` —
-/// body, headers, status, size breakdown, and phase timings. Designed
-/// to run off the UI thread via `poll_promise::Promise::spawn_thread`.
-pub fn execute_request(request: &Request, env: Option<&Environment>) -> ResponseData {
+/// Fire a single HTTP request and return a fully-populated
+/// `ResponseData` — body, headers, status, size breakdown, and phase
+/// timings. Designed to run off the UI thread via
+/// `poll_promise::Promise::spawn_thread`.
+///
+/// The `client` is shared across calls (built once from the current
+/// `AppSettings` — see `build_client`). `max_body_bytes` is the soft
+/// cap after which the body is truncated and a banner is prepended;
+/// `0` disables the cap.
+pub fn execute_request(
+    client: reqwest::Client,
+    request: &Request,
+    env: Option<&Environment>,
+    max_body_bytes: usize,
+) -> ResponseData {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let t_prepare_start = std::time::Instant::now();
 
@@ -68,7 +99,6 @@ pub fn execute_request(request: &Request, env: Option<&Environment>) -> Response
     };
 
     rt.block_on(async {
-        let client = reqwest::Client::new();
         let final_url_base = ensure_url_scheme(&final_url_base);
         let final_url = curl::build_full_url(&final_url_base, &sub_params);
 
@@ -222,10 +252,20 @@ pub fn execute_request(request: &Request, env: Option<&Environment>) -> Response
                     })
                     .collect();
 
-                let body = response
-                    .text()
-                    .await
-                    .unwrap_or_else(|e| format!("Error reading body: {}", e));
+                // Stream body with a size cap so a multi-GB payload
+                // doesn't OOM the app. We read chunks until we hit
+                // `max_body_bytes`, then stop and prepend a banner.
+                let (body, truncated) =
+                    read_body_capped(response, max_body_bytes).await;
+                let body = if truncated {
+                    let cap_mb = max_body_bytes as f64 / (1024.0 * 1024.0);
+                    format!(
+                        "/* Response body truncated at {:.1} MB (see Settings → Max body) */\n{}",
+                        cap_mb, body
+                    )
+                } else {
+                    body
+                };
                 let t_done = std::time::Instant::now();
                 let download_ms = t_done.saturating_duration_since(t_headers).as_millis() as u64;
                 let total_ms = t_done.saturating_duration_since(t_prepare_start).as_millis() as u64;
@@ -267,4 +307,47 @@ pub fn execute_request(request: &Request, env: Option<&Environment>) -> Response
             },
         }
     })
+}
+
+/// Read a response body into a String, stopping as soon as `max_bytes`
+/// is reached. Returns `(body, truncated)`. A cap of `0` disables the
+/// limit and reads the whole response (equivalent to `.text()`).
+///
+/// Uses `reqwest::Response::chunk()` so we pull incrementally from the
+/// network and abort early on oversize payloads — no 5 GB allocation
+/// just because a server returned a 5 GB body.
+async fn read_body_capped(
+    mut response: reqwest::Response,
+    max_bytes: usize,
+) -> (String, bool) {
+    if max_bytes == 0 {
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("Error reading body: {}", e));
+        return (body, false);
+    }
+    let mut buf: Vec<u8> = Vec::new();
+    let mut truncated = false;
+    loop {
+        match response.chunk().await {
+            Ok(Some(bytes)) => {
+                if buf.len() + bytes.len() > max_bytes {
+                    let remaining = max_bytes.saturating_sub(buf.len());
+                    buf.extend_from_slice(&bytes[..remaining]);
+                    truncated = true;
+                    break;
+                }
+                buf.extend_from_slice(&bytes);
+            }
+            Ok(None) => break,
+            Err(e) => {
+                let tail = format!("\n/* Error reading chunk: {} */", e);
+                buf.extend_from_slice(tail.as_bytes());
+                break;
+            }
+        }
+    }
+    // Lossy — response may stop mid-UTF-8; safer than failing.
+    (String::from_utf8_lossy(&buf).into_owned(), truncated)
 }

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -13,24 +13,40 @@ const HL_KEYWORD: Color32 = Color32::from_rgb(249, 38, 114); // pink — lang ke
 const HL_COMMENT: Color32 = Color32::from_rgb(117, 113, 94); // grey — shell comments
 const HL_LINENO: Color32 = Color32::from_rgb(100, 105, 115); // dim grey
 
-/// Build a syntax-highlighted `LayoutJob` for a code snippet. Shell-like
-/// languages (cURL, HTTPie) get strings/flags highlighted; Python/JS also
-/// pick up language keywords. The highlighter is intentionally small — no
-/// proper lexer, just enough coloring to read at a glance.
+// `build_snippet_layout_job` (the with-embedded-gutter variant) was
+// replaced by `build_snippet_layout_job_content_only` paired with a
+// separate gutter column. Kept here only if we ever need a single-
+// LayoutJob fallback; marked dead_code to keep the build quiet.
+#[allow(dead_code)]
 pub fn build_snippet_layout_job(text: &str, lang: SnippetLang, _wrap_width: f32) -> LayoutJob {
     let font = FontId::monospace(12.5);
     let mut job = LayoutJob::default();
-
     for (line_idx, line) in text.split('\n').enumerate() {
         if line_idx > 0 {
             append(&mut job, "\n", &font, HL_TEXT);
         }
-        // Line number gutter — fixed 4-char-wide, dim grey.
         let lineno = format!("{:>3}  ", line_idx + 1);
         append(&mut job, &lineno, &font, HL_LINENO);
         highlight_line(&mut job, line, lang, &font);
     }
+    job
+}
 
+/// Same as `build_snippet_layout_job` but without the line-number gutter
+/// embedded into the text. Intended to be paired with a separate gutter
+/// column rendered to the left of the content — that way wrapped visual
+/// rows of a long logical line continue inside the content column
+/// instead of snapping back to the widget's left edge and overlapping
+/// the gutter.
+pub fn build_snippet_layout_job_content_only(text: &str, lang: SnippetLang) -> LayoutJob {
+    let font = FontId::monospace(12.5);
+    let mut job = LayoutJob::default();
+    for (line_idx, line) in text.split('\n').enumerate() {
+        if line_idx > 0 {
+            append(&mut job, "\n", &font, HL_TEXT);
+        }
+        highlight_line(&mut job, line, lang, &font);
+    }
     job
 }
 

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -756,6 +756,54 @@ impl ApiClient {
                 {
                     changed = true;
                 }
+                // JWT decoder — if the token looks like `header.payload.sig`
+                // with 2 dots and each part is base64url-ish, render the
+                // decoded header + payload below.
+                if let Some((header_json, payload_json)) = try_decode_jwt(token) {
+                    ui.add_space(8.0);
+                    ui.label(
+                        egui::RichText::new("Decoded JWT")
+                            .size(11.0)
+                            .strong()
+                            .color(C_MUTED),
+                    );
+                    ui.add_space(4.0);
+                    egui::CollapsingHeader::new(
+                        egui::RichText::new("Header").color(C_TEXT).size(12.5),
+                    )
+                    .default_open(true)
+                    .show(ui, |ui| {
+                        let mut s: &str = &header_json;
+                        ui.add(
+                            egui::TextEdit::multiline(&mut s)
+                                .code_editor()
+                                .desired_rows(3)
+                                .desired_width(f32::INFINITY)
+                                .font(egui::TextStyle::Monospace),
+                        );
+                    });
+                    egui::CollapsingHeader::new(
+                        egui::RichText::new("Payload").color(C_TEXT).size(12.5),
+                    )
+                    .default_open(true)
+                    .show(ui, |ui| {
+                        let mut s: &str = &payload_json;
+                        ui.add(
+                            egui::TextEdit::multiline(&mut s)
+                                .code_editor()
+                                .desired_rows(6)
+                                .desired_width(f32::INFINITY)
+                                .font(egui::TextStyle::Monospace),
+                        );
+                    });
+                    ui.label(
+                        egui::RichText::new(
+                            "Signature is not verified — we just base64-decode the header and payload.",
+                        )
+                        .size(10.5)
+                        .color(C_MUTED),
+                    );
+                }
             }
             Auth::Basic { username, password } => {
                 ui.horizontal(|ui| {
@@ -951,4 +999,37 @@ impl ApiClient {
         }
     }
 
+}
+
+/// Attempt to decode a token as a JWT. Returns the pretty-printed
+/// header + payload as `(header_json, payload_json)` on success. We
+/// don't verify the signature — this is a dev convenience for
+/// eyeballing claims, not a security check.
+fn try_decode_jwt(token: &str) -> Option<(String, String)> {
+    let parts: Vec<&str> = token.trim().split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    let decode_segment = |s: &str| -> Option<String> {
+        use base64::Engine;
+        let padded = {
+            let pad = (4 - s.len() % 4) % 4;
+            let mut t = s.to_string();
+            for _ in 0..pad {
+                t.push('=');
+            }
+            t
+        };
+        let bytes = base64::engine::general_purpose::URL_SAFE
+            .decode(padded.as_bytes())
+            .ok()?;
+        let raw = String::from_utf8(bytes).ok()?;
+        match serde_json::from_str::<serde_json::Value>(&raw) {
+            Ok(v) => serde_json::to_string_pretty(&v).ok(),
+            Err(_) => None,
+        }
+    };
+    let header = decode_segment(parts[0])?;
+    let payload = decode_segment(parts[1])?;
+    Some((header, payload))
 }

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -230,6 +230,7 @@ impl ApiClient {
                                     );
                                 }
                                 if plus_resp
+                                    .on_hover_cursor(egui::CursorIcon::PointingHand)
                                     .on_hover_text("New request (unsaved)")
                                     .clicked()
                                 {
@@ -366,6 +367,7 @@ impl ApiClient {
 
                     let send_click = ui
                         .add_enabled(!self.is_loading, send_btn)
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
                         .on_hover_text("Send (⌘/Ctrl + Enter)")
                         .clicked();
 
@@ -375,6 +377,7 @@ impl ApiClient {
                                 .fill(C_BORDER)
                                 .min_size(egui::vec2(74.0, 28.0)),
                         )
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
                         .on_hover_text("Toggle code-snippet panel")
                         .clicked()
                     {

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -817,6 +817,123 @@ impl ApiClient {
         }
     }
 
+    /// App-wide settings modal — request timeout, body size cap, proxy,
+    /// TLS verification. Changes take effect immediately (we rebuild
+    /// the shared `reqwest::Client` on save).
+    pub(crate) fn render_settings_modal(&mut self, ctx: &egui::Context) {
+        if !self.show_settings_modal {
+            return;
+        }
+        let mut open = self.show_settings_modal;
+        let mut do_save = false;
+        let mut do_cancel = false;
+
+        egui::Window::new(
+            egui::RichText::new("SETTINGS").size(12.0).strong().color(C_MUTED),
+        )
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .default_width(440.0)
+            .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+            .show(ctx, |ui| {
+                ui.set_min_width(420.0);
+
+                // Request timeout
+                ui.label(egui::RichText::new("Request timeout (seconds)").size(11.5).color(C_MUTED));
+                ui.add(
+                    egui::DragValue::new(&mut self.editing_settings.timeout_sec)
+                        .range(0..=3600)
+                        .speed(1.0)
+                        .suffix(" s"),
+                );
+                ui.label(
+                    egui::RichText::new("0 disables the timeout (requests can hang forever).")
+                        .size(10.5)
+                        .color(C_MUTED),
+                );
+                ui.add_space(10.0);
+
+                // Max body size
+                ui.label(egui::RichText::new("Max response body (MB)").size(11.5).color(C_MUTED));
+                ui.add(
+                    egui::DragValue::new(&mut self.editing_settings.max_body_mb)
+                        .range(0..=2048)
+                        .speed(1.0)
+                        .suffix(" MB"),
+                );
+                ui.label(
+                    egui::RichText::new(
+                        "Responses larger than this are truncated with a banner. \
+                         0 disables the cap (huge payloads may OOM the app).",
+                    )
+                    .size(10.5)
+                    .color(C_MUTED),
+                );
+                ui.add_space(10.0);
+
+                // Proxy
+                ui.label(egui::RichText::new("Proxy URL").size(11.5).color(C_MUTED));
+                ui.add(
+                    egui::TextEdit::singleline(&mut self.editing_settings.proxy_url)
+                        .hint_text("http://proxy:8080 (leave empty for direct)")
+                        .desired_width(f32::INFINITY),
+                );
+                ui.add_space(10.0);
+
+                // Verify TLS
+                ui.checkbox(
+                    &mut self.editing_settings.verify_tls,
+                    "Verify TLS certificates",
+                );
+                ui.label(
+                    egui::RichText::new(
+                        "Unchecked = accept self-signed / expired certs. \
+                         Dangerous on the public internet; useful for internal dev APIs.",
+                    )
+                    .size(10.5)
+                    .color(C_MUTED),
+                );
+
+                ui.add_space(14.0);
+                ui.separator();
+                ui.add_space(6.0);
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.button("Cancel").clicked() {
+                        do_cancel = true;
+                    }
+                    let save_btn = egui::Button::new(
+                        egui::RichText::new("Save")
+                            .color(egui::Color32::WHITE)
+                            .strong(),
+                    )
+                    .fill(C_ACCENT)
+                    .min_size(egui::vec2(80.0, 28.0));
+                    if ui.add(save_btn).clicked() {
+                        do_save = true;
+                    }
+                });
+
+                ui.input(|i| {
+                    if i.key_pressed(egui::Key::Escape) {
+                        do_cancel = true;
+                    }
+                });
+            });
+        self.show_settings_modal = open;
+
+        if do_save {
+            self.state.settings = self.editing_settings.clone();
+            self.http_client = crate::net::build_client(&self.state.settings);
+            self.save_state();
+            self.show_toast("Settings saved");
+            self.show_settings_modal = false;
+        }
+        if do_cancel || !self.show_settings_modal {
+            self.show_settings_modal = false;
+        }
+    }
+
     pub(crate) fn render_toast(&mut self, ctx: &egui::Context) {
         let Some((msg, ttl)) = self.toast.clone() else {
             return;

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -957,6 +957,284 @@ impl ApiClient {
         }
     }
 
+    /// In-window menu bar along the top of the window. Cross-platform
+    /// (macOS + Linux) — egui doesn't drive the native macOS NSMenu
+    /// bar, so we render our own strip here. Keeps the same items
+    /// regardless of OS so behavior is consistent.
+    #[cfg(not(target_os = "macos"))]
+    pub(crate) fn render_menu_bar(&mut self, ctx: &egui::Context) {
+        // Actions flow out of the closures via mutable flags so we can
+        // react after the panel closes (avoids borrow conflicts with
+        // `self` inside the menu closures).
+        let mut action_new_request = false;
+        let mut action_new_collection = false;
+        let mut action_import = false;
+        let mut action_paste_curl = false;
+        let mut action_export_json = false;
+        let mut action_export_yaml = false;
+        let mut action_toggle_snippet = false;
+        let mut action_open_settings = false;
+        let mut action_open_env = false;
+        let mut action_show_about = false;
+        let mut action_quit = false;
+
+        egui::TopBottomPanel::top("menu_bar")
+            .frame(
+                egui::Frame::none()
+                    .fill(C_PANEL_DARK)
+                    .inner_margin(egui::Margin::symmetric(4.0, 2.0)),
+            )
+            .show(ctx, |ui| {
+                egui::menu::bar(ui, |ui| {
+                    ui.menu_button("File", |ui| {
+                        if ui.button("New Request").clicked() {
+                            action_new_request = true;
+                            ui.close_menu();
+                        }
+                        if ui.button("New Collection").clicked() {
+                            action_new_collection = true;
+                            ui.close_menu();
+                        }
+                        ui.separator();
+                        if ui.button("Import collection file…").clicked() {
+                            action_import = true;
+                            ui.close_menu();
+                        }
+                        if ui.button("Paste cURL command…").clicked() {
+                            action_paste_curl = true;
+                            ui.close_menu();
+                        }
+                        if ui.button("Export all as JSON…").clicked() {
+                            action_export_json = true;
+                            ui.close_menu();
+                        }
+                        if ui.button("Export all as YAML…").clicked() {
+                            action_export_yaml = true;
+                            ui.close_menu();
+                        }
+                        ui.separator();
+                        if ui.button("Quit").clicked() {
+                            action_quit = true;
+                            ui.close_menu();
+                        }
+                    });
+
+                    ui.menu_button("View", |ui| {
+                        if ui.button("Toggle code snippet panel").clicked() {
+                            action_toggle_snippet = true;
+                            ui.close_menu();
+                        }
+                    });
+
+                    ui.menu_button("Settings", |ui| {
+                        if ui.button("Preferences…").clicked() {
+                            action_open_settings = true;
+                            ui.close_menu();
+                        }
+                        if ui.button("Environments…").clicked() {
+                            action_open_env = true;
+                            ui.close_menu();
+                        }
+                    });
+
+                    ui.menu_button("Help", |ui| {
+                        if ui.button("About Rusty Requester").clicked() {
+                            action_show_about = true;
+                            ui.close_menu();
+                        }
+                        ui.separator();
+                        if ui.button("Open GitHub repo").clicked() {
+                            ctx.output_mut(|o| {
+                                o.open_url = Some(egui::output::OpenUrl {
+                                    url: "https://github.com/chud-lori/rusty-requester"
+                                        .to_string(),
+                                    new_tab: true,
+                                });
+                            });
+                            ui.close_menu();
+                        }
+                        if ui.button("Report an issue").clicked() {
+                            ctx.output_mut(|o| {
+                                o.open_url = Some(egui::output::OpenUrl {
+                                    url: "https://github.com/chud-lori/rusty-requester/issues"
+                                        .to_string(),
+                                    new_tab: true,
+                                });
+                            });
+                            ui.close_menu();
+                        }
+                    });
+                });
+            });
+
+        // Apply actions after the panel closes.
+        if action_new_request {
+            self.new_draft_request();
+        }
+        if action_new_collection {
+            self.state.folders.push(crate::model::Folder {
+                id: uuid::Uuid::new_v4().to_string(),
+                name: format!("Collection {}", self.state.folders.len() + 1),
+                requests: vec![],
+                subfolders: vec![],
+            });
+            self.save_state();
+        }
+        if action_import {
+            self.pending_import = true;
+        }
+        if action_paste_curl {
+            self.show_paste_modal = true;
+            self.paste_curl_text.clear();
+            self.paste_error.clear();
+        }
+        if action_export_json {
+            self.pending_export_json = true;
+        }
+        if action_export_yaml {
+            self.pending_export_yaml = true;
+        }
+        if action_toggle_snippet {
+            self.show_snippet_panel = !self.show_snippet_panel;
+        }
+        if action_open_settings {
+            self.editing_settings = self.state.settings.clone();
+            self.show_settings_modal = true;
+        }
+        if action_open_env {
+            self.show_env_modal = true;
+            if self.selected_env_for_edit.is_none() {
+                self.selected_env_for_edit =
+                    self.state.environments.first().map(|e| e.id.clone());
+            }
+        }
+        if action_show_about {
+            self.show_about_modal = true;
+        }
+        if action_quit {
+            ctx.send_viewport_cmd(egui::ViewportCommand::Close);
+        }
+    }
+
+    /// About dialog — minimal Postman-style layout: icon, name,
+    /// version lines, one-line tagline, three stacked plain links,
+    /// copyright. Used by both the macOS app/Help menu and the
+    /// in-window Linux menu bar.
+    pub(crate) fn render_about_modal(&mut self, ctx: &egui::Context) {
+        if !self.show_about_modal {
+            return;
+        }
+        let mut open = self.show_about_modal;
+        egui::Window::new(
+            egui::RichText::new("ABOUT").size(12.0).strong().color(C_MUTED),
+        )
+            .open(&mut open)
+            .collapsible(false)
+            .resizable(false)
+            .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+            .show(ctx, |ui| {
+                ui.set_min_width(360.0);
+
+                let open_url = |ctx: &egui::Context, url: &str| {
+                    ctx.output_mut(|o| {
+                        o.open_url = Some(egui::output::OpenUrl {
+                            url: url.to_string(),
+                            new_tab: true,
+                        });
+                    });
+                };
+                let link_row =
+                    |ui: &mut egui::Ui, label: &str, url: &str, ctx: &egui::Context| {
+                        if ui
+                            .link(
+                                egui::RichText::new(label)
+                                    .size(12.5)
+                                    .color(C_ACCENT),
+                            )
+                            .on_hover_cursor(egui::CursorIcon::PointingHand)
+                            .clicked()
+                        {
+                            open_url(ctx, url);
+                        }
+                    };
+
+                ui.vertical_centered(|ui| {
+                    ui.add_space(10.0);
+                    if let Some(tex) = &self.app_icon {
+                        ui.add(
+                            egui::Image::from_texture(tex)
+                                .fit_to_exact_size(egui::vec2(80.0, 80.0))
+                                .rounding(egui::Rounding::same(14.0)),
+                        );
+                    }
+                    ui.add_space(10.0);
+                    ui.label(
+                        egui::RichText::new("Rusty Requester")
+                            .size(19.0)
+                            .strong()
+                            .color(C_TEXT),
+                    );
+                    ui.add_space(8.0);
+                    ui.label(
+                        egui::RichText::new(concat!("Version ", env!("CARGO_PKG_VERSION")))
+                            .size(12.0)
+                            .color(C_TEXT),
+                    );
+                    ui.label(
+                        egui::RichText::new(concat!(
+                            "Build: ",
+                            env!("CARGO_PKG_VERSION"),
+                            " (native)"
+                        ))
+                        .size(11.5)
+                        .color(C_MUTED),
+                    );
+
+                    ui.add_space(12.0);
+                    ui.label(
+                        egui::RichText::new(
+                            "A native, offline, lightweight API client.",
+                        )
+                        .size(12.0)
+                        .color(C_TEXT),
+                    );
+
+                    ui.add_space(12.0);
+                    link_row(
+                        ui,
+                        "GitHub Repository",
+                        "https://github.com/chud-lori/rusty-requester",
+                        ctx,
+                    );
+                    ui.add_space(4.0);
+                    link_row(
+                        ui,
+                        "Report an issue",
+                        "https://github.com/chud-lori/rusty-requester/issues",
+                        ctx,
+                    );
+                    ui.add_space(4.0);
+                    link_row(
+                        ui,
+                        "Creator: Lori (@chud-lori)",
+                        "https://github.com/chud-lori",
+                        ctx,
+                    );
+
+                    ui.add_space(14.0);
+                    ui.label(
+                        egui::RichText::new("MIT Licensed · © Lori (@chud-lori)")
+                            .size(11.0)
+                            .color(C_MUTED),
+                    );
+                    ui.add_space(10.0);
+                });
+            });
+        if !open {
+            self.show_about_modal = false;
+        }
+    }
+
     pub(crate) fn render_toast(&mut self, ctx: &egui::Context) {
         let Some((msg, ttl)) = self.toast.clone() else {
             return;

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -6,7 +6,7 @@
 
 use crate::io::curl;
 use crate::model::*;
-use crate::snippet::{build_snippet_layout_job, render_snippet, SnippetLang};
+use crate::snippet::{build_snippet_layout_job_content_only, render_snippet, SnippetLang};
 use crate::theme::*;
 use crate::widgets::*;
 use crate::ApiClient;
@@ -696,22 +696,56 @@ impl ApiClient {
                             .auto_shrink([false, false])
                             .max_height(avail_h)
                             .show(ui, |ui| {
-                                let mut text = snippet.clone();
-                                let lang = self.snippet_lang;
-                                let mut layouter =
-                                    move |ui: &egui::Ui, s: &str, wrap_width: f32| {
-                                        let mut job =
-                                            build_snippet_layout_job(s, lang, wrap_width);
-                                        job.wrap.max_width = wrap_width;
-                                        ui.fonts(|f| f.layout_job(job))
-                                    };
-                                ui.add(
-                                    egui::TextEdit::multiline(&mut text)
-                                        .code_editor()
-                                        .interactive(false)
-                                        .desired_width(f32::INFINITY)
-                                        .layouter(&mut layouter),
-                                );
+                                // Two-column layout so wrapped lines
+                                // stay inside the content column instead
+                                // of snapping back to x=0 and colliding
+                                // with the next logical line's gutter.
+                                let gutter_w = 32.0;
+                                let line_count =
+                                    snippet.split('\n').count().max(1);
+                                ui.horizontal_top(|ui| {
+                                    // Left — line numbers. One label per
+                                    // logical line; if the content wraps
+                                    // to multiple visual rows the gutter
+                                    // will trail shorter than the content,
+                                    // which matches Postman's behavior.
+                                    ui.vertical(|ui| {
+                                        ui.spacing_mut().item_spacing.y = 0.0;
+                                        for i in 1..=line_count {
+                                            ui.add_sized(
+                                                [gutter_w, 17.0],
+                                                egui::Label::new(
+                                                    egui::RichText::new(format!(
+                                                        "{:>3}",
+                                                        i
+                                                    ))
+                                                    .color(egui::Color32::from_rgb(100, 105, 115))
+                                                    .font(egui::FontId::monospace(12.5)),
+                                                ),
+                                            );
+                                        }
+                                    });
+                                    ui.add_space(6.0);
+                                    // Right — content; TextEdit owns its
+                                    // own wrap inside the remaining width.
+                                    let mut text = snippet.clone();
+                                    let lang = self.snippet_lang;
+                                    let mut layouter =
+                                        move |ui: &egui::Ui, s: &str, wrap_width: f32| {
+                                            let mut job =
+                                                build_snippet_layout_job_content_only(s, lang);
+                                            job.wrap.max_width = wrap_width;
+                                            ui.fonts(|f| f.layout_job(job))
+                                        };
+                                    ui.add(
+                                        egui::TextEdit::multiline(&mut text)
+                                            .code_editor()
+                                            .frame(false)
+                                            .interactive(false)
+                                            .desired_width(f32::INFINITY)
+                                            .layouter(&mut layouter),
+                                    );
+                                });
                             });
                     });
             });

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -667,18 +667,7 @@ impl ApiClient {
                             }
                         });
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        if ui
-                            .add(
-                                egui::Button::new(
-                                    egui::RichText::new("Copy")
-                                        .color(egui::Color32::WHITE)
-                                        .strong(),
-                                )
-                                .fill(C_ACCENT)
-                                .min_size(egui::vec2(70.0, 26.0)),
-                            )
-                            .clicked()
-                        {
+                        if icon_button(ui, "Copy snippet", paint_copy_icon).clicked() {
                             copy_clicked = true;
                         }
                     });

--- a/src/ui/response.rs
+++ b/src/ui/response.rs
@@ -223,6 +223,7 @@ impl ApiClient {
                             let is_json = parsed.is_some();
                             let mut copy_clicked = false;
                             let mut toggle_search = false;
+                            let mut save_clicked = false;
                             ui.horizontal(|ui| {
                                 let mut view = self.body_view;
                                 body_view_pill(ui, &mut view, BodyView::Json, "JSON");
@@ -237,10 +238,20 @@ impl ApiClient {
                                             .desired_width(200.0),
                                     );
                                 }
-                                // Right-side icon buttons — search + copy.
+                                // Right-side icon buttons — save + copy + search.
                                 ui.with_layout(
                                     egui::Layout::right_to_left(egui::Align::Center),
                                     |ui| {
+                                        if icon_button(
+                                            ui,
+                                            "Save response to file",
+                                            paint_save_icon,
+                                        )
+                                        .clicked()
+                                        {
+                                            save_clicked = true;
+                                        }
+                                        ui.add_space(2.0);
                                         if icon_button(ui, "Copy response body", paint_copy_icon)
                                             .clicked()
                                         {
@@ -265,6 +276,39 @@ impl ApiClient {
                                 ui.ctx()
                                     .output_mut(|o| o.copied_text = self.response_text.clone());
                                 self.show_toast("Copied response body");
+                            }
+                            if save_clicked {
+                                // Pick an extension from Content-Type so
+                                // the default filename feels natural.
+                                let ext = match self
+                                    .response_headers
+                                    .iter()
+                                    .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+                                    .map(|(_, v)| v.to_ascii_lowercase())
+                                    .as_deref()
+                                {
+                                    Some(v) if v.contains("json") => "json",
+                                    Some(v) if v.contains("xml") => "xml",
+                                    Some(v) if v.contains("html") => "html",
+                                    Some(v) if v.contains("csv") => "csv",
+                                    _ => "txt",
+                                };
+                                if let Some(path) = rfd::FileDialog::new()
+                                    .set_file_name(format!("response.{}", ext))
+                                    .save_file()
+                                {
+                                    match std::fs::write(&path, &self.response_text) {
+                                        Ok(()) => self.show_toast(format!(
+                                            "Saved to {}",
+                                            path.file_name()
+                                                .and_then(|n| n.to_str())
+                                                .unwrap_or("file")
+                                        )),
+                                        Err(e) => {
+                                            self.show_toast(format!("Save failed: {}", e))
+                                        }
+                                    }
+                                }
                             }
                             if self.body_search_visible {
                                 ui.add_space(4.0);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -66,6 +66,23 @@ impl ApiClient {
                                 .color(C_MUTED),
                         );
                     });
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        if ui
+                            .add(
+                                egui::Button::new(
+                                    egui::RichText::new("⚙").size(14.0).color(C_MUTED),
+                                )
+                                .min_size(egui::vec2(26.0, 24.0))
+                                .fill(egui::Color32::TRANSPARENT)
+                                .stroke(egui::Stroke::NONE),
+                            )
+                            .on_hover_text("Settings (timeout, body cap, proxy, TLS)")
+                            .clicked()
+                        {
+                            self.editing_settings = self.state.settings.clone();
+                            self.show_settings_modal = true;
+                        }
+                    });
                 });
                 ui.add_space(6.0);
                 self.render_environment_picker(ui);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -76,6 +76,7 @@ impl ApiClient {
                                 .fill(egui::Color32::TRANSPARENT)
                                 .stroke(egui::Stroke::NONE),
                             )
+                            .on_hover_cursor(egui::CursorIcon::PointingHand)
                             .on_hover_text("Settings (timeout, body cap, proxy, TLS)")
                             .clicked()
                         {
@@ -109,7 +110,11 @@ impl ApiClient {
                     .stroke(egui::Stroke::NONE)
                     .rounding(egui::Rounding::same(5.0))
                     .min_size(tab_size);
-                    if ui.add(coll_btn).clicked() {
+                    if ui
+                        .add(coll_btn)
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .clicked()
+                    {
                         self.sidebar_view = SidebarView::Collections;
                     }
 
@@ -128,7 +133,11 @@ impl ApiClient {
                     .stroke(egui::Stroke::NONE)
                     .rounding(egui::Rounding::same(5.0))
                     .min_size(tab_size);
-                    if ui.add(hist_btn).clicked() {
+                    if ui
+                        .add(hist_btn)
+                        .on_hover_cursor(egui::CursorIcon::PointingHand)
+                        .clicked()
+                    {
                         self.sidebar_view = SidebarView::History;
                     }
                 });
@@ -151,6 +160,7 @@ impl ApiClient {
                         .rounding(egui::Rounding::same(8.0))
                         .stroke(egui::Stroke::NONE),
                     )
+                    .on_hover_cursor(egui::CursorIcon::PointingHand)
                     .clicked()
                 {
                     self.state.folders.push(Folder {
@@ -366,6 +376,7 @@ impl ApiClient {
                         .fill(egui::Color32::TRANSPARENT)
                         .stroke(egui::Stroke::new(1.0, C_BORDER)),
                 )
+                .on_hover_cursor(egui::CursorIcon::PointingHand)
                 .on_hover_text("Manage environments")
                 .clicked()
             {
@@ -552,6 +563,7 @@ impl ApiClient {
                     egui::vec2(ui.available_width(), row_h),
                     egui::Sense::click(),
                 );
+                let resp = resp.on_hover_cursor(egui::CursorIcon::PointingHand);
 
                 if ui.is_rect_visible(rect) {
                     let bg = if is_selected {
@@ -798,7 +810,9 @@ impl ApiClient {
             );
 
             let plus_id = ui.id().with(("folder_plus", &folder_id));
-            let plus_resp = ui.interact(plus_rect, plus_id, egui::Sense::click());
+            let plus_resp = ui
+                .interact(plus_rect, plus_id, egui::Sense::click())
+                .on_hover_cursor(egui::CursorIcon::PointingHand);
             if plus_resp.hovered() {
                 ui.painter()
                     .rect_filled(plus_rect, egui::Rounding::same(4.0), C_ELEVATED);
@@ -811,7 +825,9 @@ impl ApiClient {
             }
 
             let dots_id = ui.id().with(("folder_dots", &folder_id));
-            let dots_resp = ui.interact(dots_rect, dots_id, egui::Sense::click());
+            let dots_resp = ui
+                .interact(dots_rect, dots_id, egui::Sense::click())
+                .on_hover_cursor(egui::CursorIcon::PointingHand);
             if dots_resp.hovered() {
                 ui.painter()
                     .rect_filled(dots_rect, egui::Rounding::same(4.0), C_ELEVATED);

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -552,6 +552,42 @@ pub fn paint_folder_chevron(ui: &mut egui::Ui, openness: f32, response: &egui::R
     ));
 }
 
+/// Paints a download / save icon — a downward arrow over a tray — at
+/// the given center. Used for "Save response to file".
+pub fn paint_save_icon(painter: &egui::Painter, center: egui::Pos2, color: egui::Color32) {
+    let stroke = egui::Stroke::new(1.4, color);
+    // Downward arrow
+    painter.line_segment(
+        [
+            egui::pos2(center.x, center.y - 5.0),
+            egui::pos2(center.x, center.y + 2.0),
+        ],
+        stroke,
+    );
+    painter.line_segment(
+        [
+            egui::pos2(center.x - 3.0, center.y - 1.0),
+            egui::pos2(center.x, center.y + 2.0),
+        ],
+        stroke,
+    );
+    painter.line_segment(
+        [
+            egui::pos2(center.x + 3.0, center.y - 1.0),
+            egui::pos2(center.x, center.y + 2.0),
+        ],
+        stroke,
+    );
+    // Tray base
+    painter.line_segment(
+        [
+            egui::pos2(center.x - 5.0, center.y + 5.0),
+            egui::pos2(center.x + 5.0, center.y + 5.0),
+        ],
+        stroke,
+    );
+}
+
 /// Paints a thin plus icon (two crossed lines) at the given center.
 pub fn paint_plus_icon(painter: &egui::Painter, center: egui::Pos2, color: egui::Color32) {
     let stroke = egui::Stroke::new(1.4, color);

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -91,7 +91,8 @@ pub fn close_x_button(ui: &mut egui::Ui, hover_text: &str) -> egui::Response {
         let color = if hovered { C_RED } else { C_MUTED };
         paint_x(ui.painter(), rect.center(), 4.0, color, 1.5);
     }
-    resp.on_hover_text(hover_text)
+    resp.on_hover_cursor(egui::CursorIcon::PointingHand)
+        .on_hover_text(hover_text)
 }
 
 pub fn tab_button<T: PartialEq + Copy>(
@@ -115,7 +116,7 @@ pub fn tab_button<T: PartialEq + Copy>(
         .stroke(egui::Stroke::NONE)
         .rounding(egui::Rounding::same(6.0))
         .min_size(egui::vec2(90.0, 30.0));
-    let resp = ui.add(btn);
+    let resp = ui.add(btn).on_hover_cursor(egui::CursorIcon::PointingHand);
     if selected {
         let rect = resp.rect;
         let y = rect.bottom() - 1.0;
@@ -363,10 +364,11 @@ pub fn render_single_tab(
 ) -> TabAction {
     let tab_height = 32.0;
     let tab_width = 180.0;
-    let (rect, resp) = ui.allocate_exact_size(
+    let (rect, mut resp) = ui.allocate_exact_size(
         egui::vec2(tab_width, tab_height),
         egui::Sense::click(),
     );
+    resp = resp.on_hover_cursor(egui::CursorIcon::PointingHand);
 
     let mut action = TabAction::None;
 
@@ -552,6 +554,24 @@ pub fn paint_folder_chevron(ui: &mut egui::Ui, openness: f32, response: &egui::R
     ));
 }
 
+/// Extension trait that lets any clickable `egui::Response` opt into
+/// the pointing-hand cursor with a single short method call, so we
+/// don't repeat `.on_hover_cursor(CursorIcon::PointingHand)` dozens
+/// of times. Web browsers show the hand cursor on links/buttons by
+/// default; egui doesn't — this just restores that expectation.
+/// Retained (even though most call sites currently inline
+/// `.on_hover_cursor(...)`) so new buttons can opt in with `.hand()`.
+#[allow(dead_code)]
+pub trait HandCursor {
+    fn hand(self) -> Self;
+}
+#[allow(dead_code)]
+impl HandCursor for egui::Response {
+    fn hand(self) -> Self {
+        self.on_hover_cursor(egui::CursorIcon::PointingHand)
+    }
+}
+
 /// Paints a download / save icon — a downward arrow over a tray — at
 /// the given center. Used for "Save response to file".
 pub fn paint_save_icon(painter: &egui::Painter, center: egui::Pos2, color: egui::Color32) {
@@ -649,7 +669,8 @@ pub fn icon_button(
         }
         paint(&ui.painter(), rect.center(), color);
     }
-    resp.on_hover_text(hover_text)
+    resp.on_hover_cursor(egui::CursorIcon::PointingHand)
+        .on_hover_text(hover_text)
 }
 
 /// Paints a clean outlined folder silhouette at the given center point.
@@ -728,21 +749,23 @@ pub fn body_view_pill(
     } else {
         egui::Color32::TRANSPARENT
     };
-    let resp = ui.add(
-        egui::Button::new(
-            egui::RichText::new(label)
-                .size(12.0)
-                .color(fg)
-                .strong(),
+    let resp = ui
+        .add(
+            egui::Button::new(
+                egui::RichText::new(label)
+                    .size(12.0)
+                    .color(fg)
+                    .strong(),
+            )
+            .fill(bg)
+            .stroke(egui::Stroke::new(
+                1.0,
+                if is_active { C_ACCENT } else { C_BORDER },
+            ))
+            .min_size(egui::vec2(64.0, 22.0))
+            .rounding(egui::Rounding::same(6.0)),
         )
-        .fill(bg)
-        .stroke(egui::Stroke::new(
-            1.0,
-            if is_active { C_ACCENT } else { C_BORDER },
-        ))
-        .min_size(egui::vec2(64.0, 22.0))
-        .rounding(egui::Rounding::same(6.0)),
-    );
+        .on_hover_cursor(egui::CursorIcon::PointingHand);
     if resp.clicked() {
         *current = value;
     }


### PR DESCRIPTION
  ## Summary
  - Settings modal: request timeout, body cap, proxy, TLS verify
  - Reused `reqwest::Client` + runtime
  - Response streaming with body cap + truncation banner
  - Save response to file, JWT decoder, code-snippet gutter fix
  - Inline folder toolbar (`+` / `⋯`), duplicate folder
  - Native macOS NSMenu bar via `muda` + custom About modal
  - Pointing-hand cursors on all clickable surfaces
  - Fixed sidebar width-jitter, fixed Env picker cramping

  ## Test plan
  - [x] `cargo build --release` clean, 14/14 tests pass
  - [x] `--version` prints correct
  - [x] Smoke-tested settings, save-response, JWT decode, native menu, About modal