### PR TITLE
feat/v1 prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,31 @@ upgrades read old files cleanly.
 ## Unreleased — v1.0 prep
 
 ### Added
-- _see 1.0 pathway items in the Roadmap section of the README._
+- **Actions palette (⇧⌘P)** — fuzzy-find + run any of 16 built-in app
+  actions: New request, Duplicate / Close tab, Toggle pin, Save draft,
+  Copy as cURL, Toggle snippet panel, Open environments, Open settings,
+  Paste cURL, Import collection, Export JSON / YAML, Clear history,
+  Toggle sidebar History/Collections, About. Self-discoverable — open
+  the palette and type. Shortcut column on the right for actions that
+  also have a keybinding.
+- **Response diff** — sending a request twice populates a **Diff** pill
+  in the body toolbar. Unified `+/-` line-diff against the previous
+  response, `+A −B` summary header. Backed by an LCS-based diff
+  implementation in `src/diff.rs` (5 unit tests, zero deps).
+
+### Changed
+- **`data.json` trims defaults.** Added `skip_serializing_if` on
+  `Folder.description` (empty string), `StoredCookie.domain`,
+  `StoredCookie.secure` / `http_only`, and `OpenTab.pinned` (false).
+  Reads stay forward-compatible (all fields use `serde(default)`).
+- **README + CHANGELOG overhaul.** README now reflects every v0.6 →
+  v0.10 feature (Cancel, HTML Preview, URL↔Params sync, Phosphor
+  icons, save-draft confirmation, ⌘N / ⌘W / ⌘D / ⇧⌘P shortcuts, SSE,
+  pinned tabs, arrow nav, diff). Architecture section updated to
+  mention `egui-phosphor`, the `RequestUpdate` streaming enum, and
+  the new `sse` / `html_preview` / `actions` / `diff` modules.
+  CHANGELOG filled in entries for v0.6 through v0.10 (previously
+  stuck at v0.5.1).
 
 ## [0.10.0] — Server-Sent Events
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,89 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
-## Unreleased
+## Unreleased — v1.0 prep
 
-- _placeholder for the next release_
+### Added
+- _see 1.0 pathway items in the Roadmap section of the README._
+
+## [0.10.0] — Server-Sent Events
+
+### Added
+- **Server-Sent Events (SSE)** support. Responses with Content-Type
+  `text/event-stream` are auto-detected and stream into a structured
+  **Events** body-view — one collapsible row per event with
+  `#N event-type · HH:MM:SS.mmm` headers, per-event JSON pretty-print,
+  id / retry fields, and Copy-data button. Auto-scrolls while live,
+  pulsing "Listening…" indicator at the bottom.
+- New `src/sse.rs` module (8 unit tests, zero deps) — incremental
+  line-oriented parser handling multi-line data, CRLF, comments,
+  chunked splits.
+- `RequestUpdate::Progress { snapshot, new_events }` / `Final`
+  enum so the send task can emit multiple updates through the existing
+  `mpsc::channel` without changing cancel semantics. Cancel still
+  instantly aborts the stream via `JoinHandle::abort()`.
+
+## [0.9.1] — Quick wins
+
+### Added
+- **Duplicate tab (⌘D)** and **Pinned tabs** — right-click menu gains
+  "Duplicate tab" and "Pin tab" / "Unpin tab". Pinned tabs skip ⌘W,
+  "Close others", and "Close all". Accent-colored pin glyph in the tab
+  strip.
+- **↑ / ↓ arrow-key navigation** through every request in the sidebar
+  (wraps at both ends). Gated on `ctx.wants_keyboard_input()` so
+  text-field cursor movement isn't hijacked.
+
+### Removed
+- Redundant "→ http" scheme indicator next to the URL bar (now that
+  we always prepend http, the hint added no information).
+
+## [0.9.0] — Icon font
+
+### Added
+- Replaced every hand-drawn painter icon (search, X, save, plus,
+  three-dots, copy, folder, unplugged-plug, warning) with
+  **Phosphor icon font glyphs** via the `egui-phosphor` crate.
+  Crisp at every DPI, tintable via `RichText::color()`,
+  zero image assets.
+- `theme::hint()` helper rendering dim-colored placeholder text —
+  fixes the "Key / Value / Description" placeholders looking like
+  real data in KV tables and the URL hint.
+
+## [0.8.0] — Draft-close confirmation
+
+### Added
+- **"Save changes?" modal** when closing a draft tab that has
+  unsaved content (URL / body / headers filled in). Options:
+  Don't save · Cancel · Save changes. Empty drafts still close
+  silently.
+- **⌘N** (new request) and **⌘W** (close tab) keyboard shortcuts
+  (menu accelerators on macOS, egui input on Linux/Windows).
+
+## [0.7.0–0.7.4] — Streaming, cancel, HTML preview, URL↔Params sync
+
+### Added
+- **Cancel button** — Send flips to Cancel while a request is in
+  flight. Aborts the tokio task; dropping the future mid-`.await`
+  also drops the hyper connection, so cancel is immediate.
+- **HTML Preview** body view — strips `<script>`/`<style>`, replaces
+  block tags with newlines, decodes entities. Pill only surfaces for
+  `text/html` responses.
+- **Illustrated failed / cancelled state** replacing the plain error
+  text: large Phosphor icon (WIFI_SLASH / PROHIBIT), headline pill,
+  error-detail chip, context hint line.
+- **Bidirectional URL ↔ Params sync** (Postman-style): typing
+  `?foo=bar` in the URL populates the Params tab; editing the table
+  rebuilds the URL bar.
+- Stable `id_source("url_bar_edit")` on the URL TextEdit so its undo
+  buffer survives widget re-creation.
+- Code snippets (cURL / Python / JS / HTTPie) now apply the same
+  `ensure_url_scheme` as the send path — the displayed command
+  matches what's actually sent.
+
+## [0.6.0–0.6.2] — Tier 3 polish
+
+(See individual release tags for per-patch detail.)
 
 ## [0.5.1] — Tier 3 wrap + CI fix
 

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ and of managing a wall of raw <code>curl</code> commands in my terminal.
 - 🛈 **Time hover tooltip** — gantt-style phase breakdown: Prepare · Waiting (TTFB) · Download
 - 🧩 **Body view modes**: **JSON** (syntax-highlighted code editor with line numbers), **Tree** (collapsible JSON tree with filter + right-click "Copy path"), **Preview** (HTML rendered as readable text for error pages / login challenges), **Events** (structured log for `text/event-stream` / SSE responses), **Raw** (verbatim) — pills are inline with the section tabs and don't scroll away
 - 📡 **Server-Sent Events (SSE)** — native streaming support for LLM / event-stream APIs. Auto-detected by `Content-Type: text/event-stream`; events flow into a collapsible-per-row Events view with auto-scroll, per-event timestamps, and JSON-pretty-printed data. Cancel aborts the stream instantly.
+- 🔀 **Response diff** — send a request twice to compare. The **Diff** pill shows a unified `+/-` line-diff of the current response against the previous one, with `+A −B` summary.
 - 🛑 **Cancel button** — Send flips to Cancel while a request is in flight. Instantly aborts the tokio task + underlying hyper connection (no per-chunk polling).
 - 🖼 **Failed/cancelled state** — dedicated illustrated screen with status headline + error-detail pill instead of opaque text, for network failures, TLS issues, or user cancels.
 - 🔍 **Find in body** — toolbar search icon highlights all matches inline
@@ -90,8 +91,9 @@ and of managing a wall of raw <code>curl</code> commands in my terminal.
 - 🎛 **Settings modal** — request timeout, max body size cap (50 MB default; truncates with banner), proxy URL, TLS verification toggle. All persisted to disk.
 - 🔌 **Reused HTTP client + tokio runtime** — no per-request connection-pool / runtime spinup; faster repeated sends.
 - ⌨️ **⌘P command palette** — fuzzy-find any request across every collection, ↑↓ navigate, Enter to open
+- ⌨️ **⇧⌘P actions palette** — fuzzy-find an app **action** (New request, Duplicate tab, Toggle snippet panel, Copy as cURL, Open environments, Clear history, …). Fully discoverable — open the palette and start typing.
 - ⌨️ **↑ / ↓ arrow nav** — step through every request across every collection when nothing's focused; wraps at both ends
-- ⌨️ Standard shortcuts: **⌘⏎** Send · **⌘N** New request · **⌘W** Close tab · **⌘D** Duplicate tab · **⌘K** Focus search · **⌘S** Save draft · **⌘P** Command palette · **F2** Rename · **Esc** Dismiss modals
+- ⌨️ Standard shortcuts: **⌘⏎** Send · **⌘N** New request · **⌘W** Close tab · **⌘D** Duplicate tab · **⌘K** Focus search · **⌘S** Save draft · **⌘P** Command palette · **⇧⌘P** Actions palette · **F2** Rename · **Esc** Dismiss modals
 - 🍎 **Native macOS NSMenu bar** (Rusty Requester · File · View · Request · Help) via `muda`; in-window menu on Linux
 - 🎨 **Phosphor icon font** — 1,200+ tintable icons rendered as font glyphs; crisp at every DPI, zero image assets to ship
 - ℹ **Help → About** opens a custom modal with creator credit + Contribute / Report-issue links
@@ -331,6 +333,7 @@ Type in the **🔎 Search** box in the sidebar. It filters by request name, URL,
 - **⌘/Ctrl + D** → Duplicate active tab
 - **⌘/Ctrl + K** → Focus the sidebar search
 - **⌘/Ctrl + P** → Command palette (fuzzy request finder)
+- **⇧⌘/Ctrl⇧ + P** → Actions palette (fuzzy app-action finder — type to see every available action)
 - **⌘/Ctrl + S** → Save current draft to a folder
 - **↑ / ↓** → Arrow-nav through every request (when no modal or text field is focused)
 - **F2** → Rename the active request (VS Code / Finder convention)
@@ -551,6 +554,8 @@ Workflow
 Response viewing
 - [x] **Body view modes**: JSON (syntax-highlighted code, line numbers), Tree (collapsible JSON tree with **right-click "Copy path"**), **Preview** (HTML rendered as readable text), **Events** (structured SSE log), Raw
 - [x] **Server-Sent Events (SSE)** — streaming support for LLM / event-stream APIs with live Events view (auto-scroll, per-event timestamps, JSON pretty-print)
+- [x] **Response diff** — send twice to the same request → Diff pill shows unified `+/-` line-diff with `+A −B` summary
+- [x] **⇧⌘P actions palette** — fuzzy-find app actions (16 built-in: New / Duplicate / Close tab, Save draft, Copy as cURL, Toggle snippet panel, Open environments, Open settings, Paste cURL, Import/Export, Clear history, etc.)
 - [x] **Cancel button** — Send flips to Cancel while in flight; instantly aborts the tokio task
 - [x] **Illustrated failed/cancelled state** — network failure / TLS / cancel screens with detail pill instead of raw text
 - [x] Find-in-body, copy-body, **save-response-to-file**
@@ -584,9 +589,6 @@ Platform
       system.
 - [ ] **Light theme** — parallel palette behind a Settings toggle. The dark default
       stays unchanged.
-- [ ] **Response diff** — "send twice, diff me" between two recent responses.
-- [ ] **⇧⌘P actions palette** — ⌘P finds requests; ⇧⌘P triggers app actions
-      (toggle snippet panel, duplicate tab, clear history, etc.).
 
 **Post-1.0:**
 

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ and of managing a wall of raw <code>curl</code> commands in my terminal.
 ### Request building
 - 🔧 Full HTTP methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`
 - 📝 Tabbed editor: **Params · Headers · Cookies · Body · Auth · Tests**
-- 🔗 Query-param builder with live "final URL" preview and auto-growing "ghost" row (type and a new empty row appears below)
+- 🔗 **Bidirectional URL ↔ Params sync** (Postman-style): type `?foo=bar` in the URL bar → params populate the table; edit the table → URL bar rebuilds. Auto-growing "ghost" row.
 - 🍪 Cookies list (merged into a `Cookie` header on send)
 - 🔐 Auth presets: **No Auth · Bearer Token · Basic Auth** + **JWT decoder** (Bearer tokens auto-decode below the input — header & payload pretty JSON, scope/exp at a glance)
 - 📦 **Body modes**: Raw / `x-www-form-urlencoded` / `multipart/form-data` / **GraphQL** (query + variables, sent as `application/json`)
@@ -46,7 +46,10 @@ and of managing a wall of raw <code>curl</code> commands in my terminal.
 - 📊 Status pill + response time + size rendered inline with the Body/Headers tab row, on the right (Postman-style: `Body  Headers  JSON Tree Raw  [🔍][📋][💾]    200 OK · 54 ms · 434 B`)
 - 🛈 **Size hover tooltip** — breakdown of response headers/body and request headers/body bytes
 - 🛈 **Time hover tooltip** — gantt-style phase breakdown: Prepare · Waiting (TTFB) · Download
-- 🧩 **Body view modes**: **JSON** (syntax-highlighted code editor with line numbers), **Tree** (collapsible JSON tree with filter + right-click "Copy path"), **Raw** (verbatim) — pills are inline with the section tabs and don't scroll away
+- 🧩 **Body view modes**: **JSON** (syntax-highlighted code editor with line numbers), **Tree** (collapsible JSON tree with filter + right-click "Copy path"), **Preview** (HTML rendered as readable text for error pages / login challenges), **Events** (structured log for `text/event-stream` / SSE responses), **Raw** (verbatim) — pills are inline with the section tabs and don't scroll away
+- 📡 **Server-Sent Events (SSE)** — native streaming support for LLM / event-stream APIs. Auto-detected by `Content-Type: text/event-stream`; events flow into a collapsible-per-row Events view with auto-scroll, per-event timestamps, and JSON-pretty-printed data. Cancel aborts the stream instantly.
+- 🛑 **Cancel button** — Send flips to Cancel while a request is in flight. Instantly aborts the tokio task + underlying hyper connection (no per-chunk polling).
+- 🖼 **Failed/cancelled state** — dedicated illustrated screen with status headline + error-detail pill instead of opaque text, for network failures, TLS issues, or user cancels.
 - 🔍 **Find in body** — toolbar search icon highlights all matches inline
 - 📋 **Copy response body** + 💾 **Save response to file** (Content-Type → file extension auto-suggested)
 - 📑 Separate **Body / Headers** tabs; rust-orange accent on header keys
@@ -77,12 +80,20 @@ and of managing a wall of raw <code>curl</code> commands in my terminal.
 - 📥 **Import** JSON, YAML, or **Postman Collection v2.1** files
 - ✏️ Rename via double-click or right-click
 
+### Tabs
+- 📑 **Multi-tab workspace** — open many requests in parallel; tabs persist across quit/relaunch
+- ⚓ **Pinned tabs** — right-click → **Pin tab** keeps a tab around; ⌘W and "Close all" skip pinned tabs (accent-colored pin glyph in the tab strip)
+- 🧬 **Duplicate tab** — **⌘D** (or right-click → Duplicate tab) clones the current request as a new draft with `(copy)` appended to the name
+- 💾 **"Save changes?" confirmation** — closing a draft tab with unsaved content opens a modal (Don't save · Cancel · Save changes)
+
 ### Workflow
 - 🎛 **Settings modal** — request timeout, max body size cap (50 MB default; truncates with banner), proxy URL, TLS verification toggle. All persisted to disk.
 - 🔌 **Reused HTTP client + tokio runtime** — no per-request connection-pool / runtime spinup; faster repeated sends.
 - ⌨️ **⌘P command palette** — fuzzy-find any request across every collection, ↑↓ navigate, Enter to open
-- ⌨️ Standard shortcuts: ⌘⏎ Send · ⌘K focus search · ⌘S save draft · F2 rename · Esc dismiss modals
+- ⌨️ **↑ / ↓ arrow nav** — step through every request across every collection when nothing's focused; wraps at both ends
+- ⌨️ Standard shortcuts: **⌘⏎** Send · **⌘N** New request · **⌘W** Close tab · **⌘D** Duplicate tab · **⌘K** Focus search · **⌘S** Save draft · **⌘P** Command palette · **F2** Rename · **Esc** Dismiss modals
 - 🍎 **Native macOS NSMenu bar** (Rusty Requester · File · View · Request · Help) via `muda`; in-window menu on Linux
+- 🎨 **Phosphor icon font** — 1,200+ tintable icons rendered as font glyphs; crisp at every DPI, zero image assets to ship
 - ℹ **Help → About** opens a custom modal with creator credit + Contribute / Report-issue links
 
 ---
@@ -315,10 +326,17 @@ Type in the **🔎 Search** box in the sidebar. It filters by request name, URL,
 
 - **⌘/Ctrl + Enter** → Send the current request (from anywhere)
 - **Enter** (in URL field) → Send request
+- **⌘/Ctrl + N** → New request tab
+- **⌘/Ctrl + W** → Close active tab (skips pinned; prompts to save on unsaved drafts)
+- **⌘/Ctrl + D** → Duplicate active tab
 - **⌘/Ctrl + K** → Focus the sidebar search
+- **⌘/Ctrl + P** → Command palette (fuzzy request finder)
+- **⌘/Ctrl + S** → Save current draft to a folder
+- **↑ / ↓** → Arrow-nav through every request (when no modal or text field is focused)
 - **F2** → Rename the active request (VS Code / Finder convention)
 - **Double-click a request** in the sidebar → Inline rename
 - **Esc** during rename → Cancel; **Enter** → Save
+- **Right-click a tab** → Save to folder / Duplicate / Pin / Close / Close others / Close all
 - **Right-click a request** → Rename / Duplicate / Delete
 - **Right-click a collection / folder** → Rename / Add subfolder / Export / Delete
 
@@ -359,49 +377,56 @@ The primary UI accent (selected tab, Send button, focus ring) is the brand
 
 ### Collection vs folder
 
-Nested folders render with a small painter-drawn folder glyph (outlined
-silhouette); top-level collections intentionally omit the glyph so users
-can tell the two apart at a glance. The same font-safe approach is used
-for the collapse chevron (painter triangle), search / copy / plus /
-overflow-menu icons, and all UI tooling — no unicode glyphs, so nothing
-renders as a "tofu" square on systems where egui's bundled font lacks
-the character.
+Nested folders render with a small folder glyph; top-level collections
+intentionally omit the glyph so users can tell the two apart at a
+glance. Icons throughout the UI come from the embedded **Phosphor** icon
+font (via `egui-phosphor`) — tintable by color, crisp at every DPI, no
+PNG/SVG assets. The collapse-header chevron is a hand-painted triangle
+because it animates its rotation openness as the folder expands.
 
 ---
 
 ## 🏗️ Architecture
 
 - **`eframe` / `egui`** — immediate-mode native GUI (the whole UI)
+- **`egui-phosphor`** — embedded Phosphor icon font (1,200+ glyphs as typed constants)
 - **`reqwest`** — HTTP client
-- **`tokio`** — async runtime (used for the single send; runs on a background thread via `poll-promise`)
+- **`tokio`** — async runtime. Sends spawn onto a long-lived multi-thread runtime as `JoinHandle`s so **Cancel** can `.abort()` mid-flight; the result flows back through an `mpsc::channel` the UI polls.
 - **`serde` / `serde_json` / `serde_yaml`** — persistence + import / export
+- **`muda`** — native macOS NSMenu bar
 - **`base64`** — Basic auth encoding
 - **`rfd`** — native open / save file dialogs
 - **`uuid`** — stable IDs for folders / requests
 
-Source layout (~10 KLOC across 18 files):
+Source layout:
 
 ```
 src/
   main.rs              # ApiClient struct + core state + fn main + macOS menu dispatch
   model.rs             # Data types — Request, Folder, Auth, HttpMethod, KvRow,
                        #   ResponseExtractor, ResponseAssertion, AppSettings,
-                       #   Environment (with cookie jar), StoredCookie, ...
-  theme.rs             # Rust-forge color constants + global egui style
-  widgets.rs           # Reusable widgets — kv_table, body view pills, icon painters,
+                       #   Environment (with cookie jar), StoredCookie, OpenTab, ...
+  theme.rs             # Rust-forge color constants + global egui style + Phosphor
+                       #   font registration + `hint()` styled-placeholder helper
+  widgets.rs           # Reusable widgets — kv_table, body view pills, icon button,
                        #   JSON tree (with right-click "Copy path"), tooltip panels,
-                       #   tab pills, drag/drop helpers
+                       #   tab strip (with pin/duplicate/close actions), animated
+                       #   folder chevron
   net.rs               # execute_request + reqwest::Client / tokio::Runtime builders +
-                       #   URL scheme, error formatting (no UI deps; unit-testable)
+                       #   URL scheme, error formatting, RequestUpdate enum for
+                       #   streaming responses (Progress/Final), SSE streaming path
+  sse.rs               # SSE wire-format parser + event formatter (8 tests, zero deps)
   snippet.rs           # Code-snippet generators + syntax highlighters (cURL / JSON /
-                       #   Python / JS) with line-number gutter
+                       #   Python / JS / HTTPie) with line-number gutter
+  html_preview.rs      # Minimal HTML → readable-text renderer for the Preview body
+                       #   view (strips script/style, decodes entities; 5 tests)
   extract.rs           # Dot/bracket JSON-path evaluator for extractors (5 tests)
   assertion.rs         # Assertion evaluator (status/header/body × 7 ops) +
                        #   tiny regex engine (no `regex` crate dep) (7 tests)
   cookies.rs           # RFC 6265-ish cookie jar — parse Set-Cookie, host/path
                        #   matching, expiry pruning (8 tests)
   macos_menu.rs        # Native NSMenu via muda — App / File / View / Request /
-                       #   Help submenus + ⌘P / ⌘⏎ / ⇧⌘C accelerators
+                       #   Help submenus + ⌘N / ⌘W / ⌘P / ⌘⏎ / ⇧⌘C accelerators
   icon.rs              # App icon loading (texture + window icon + macOS dock icon)
   io/
     mod.rs             # JSON / YAML export + Postman v2.1 import       (unit-tested)
@@ -410,14 +435,16 @@ src/
     mod.rs             # submodule wiring
     sidebar.rs         # left panel — collections tree, env picker, history, folder
                        #   row drag-to-reorder, search box
-    editor.rs          # central panel — tabs bar, URL bar, request-editor tabs
+    editor.rs          # central panel — tab strip, URL bar, request-editor tabs
                        #   (Params/Headers/Cookies/Body/Auth/Tests), collection
                        #   overview page, JWT decoder
     response.rs        # response panel — inline status chips, body toolbar
-                       #   (JSON/Tree/Raw), search, copy, save, headers grid,
-                       #   loading spinner, empty state
-    modals.rs          # env mgr, save-draft folder picker, cURL paste, snippet
-                       #   panel, settings, About modal, command palette (⌘P), toast
+                       #   (JSON/Tree/Preview/Events/Raw), search, copy, save,
+                       #   headers grid, loading spinner, illustrated failed state,
+                       #   structured SSE Events log
+    modals.rs          # env mgr, save-draft folder picker, "Save changes?" confirm,
+                       #   cURL paste, snippet panel, settings, About modal,
+                       #   command palette (⌘P), toast
 
 assets/
   icon.png             # 512×512 generated by scripts/generate_icon.py
@@ -429,8 +456,8 @@ scripts/
 install.sh             # macOS + Linux one-line installer
 ```
 
-29 unit tests across `extract`, `assertion`, `cookies`, `io`, `io::curl`. Run
-`cargo test` to verify everything builds + passes.
+44 unit tests across `extract`, `assertion`, `cookies`, `io`, `io::curl`,
+`html_preview`, and `sse`. Run `cargo test` to verify everything builds + passes.
 
 ---
 
@@ -497,14 +524,14 @@ Applications and you're done.
 
 ## 🗺️ Roadmap
 
-**Shipped through v0.5:**
+**Shipped through v0.10:**
 
 Foundations
 - [x] Full HTTP methods, tabbed editor (Params / Headers / Cookies / Body / Auth / Tests)
 - [x] cURL import (paste in URL bar) / export (right-side code panel: cURL, Python, JS, HTTPie) with syntax-highlighted line-numbered code view
 - [x] Postman Collection v2.1 import
 - [x] JSON / YAML export & import
-- [x] Query parameter builder + auto-growing ghost row pattern for all KV tables
+- [x] Bidirectional **URL ↔ Params sync** — type `?k=v` in URL, table populates; edit table, URL rebuilds
 - [x] Bearer / Basic auth presets + **JWT decoder** for Bearer tokens
 - [x] Body modes: Raw / form-urlencoded / multipart / GraphQL
 - [x] Environment variables — `{{var}}` substitution with active env selector + manage modal
@@ -512,14 +539,20 @@ Foundations
 
 Workflow
 - [x] Postman-style request tabs (open multiple requests, switch with one click) with hover preview
+- [x] **Duplicate tab (⌘D) and pinned tabs** — pinned tabs skip ⌘W / "Close all"
+- [x] **"Save changes?" confirmation** — closing a draft with unsaved content prompts (Don't save / Cancel / Save)
 - [x] Inline rename via double-click; F2 shortcut
 - [x] Subfolders; collection overview page; inline folder `+`/`⋯` toolbar; duplicate folder recursively; save-draft folder picker with inline "New folder"
 - [x] Drag-to-reorder requests within a folder
 - [x] Search across requests, URLs, methods, folder names (⌘K)
 - [x] **⌘P command palette** — fuzzy-find any request and jump
+- [x] **↑/↓ arrow navigation** through every request in the sidebar
 
 Response viewing
-- [x] **Body view modes**: JSON (syntax-highlighted code, line numbers), Tree (collapsible JSON tree with **right-click "Copy path"**), Raw
+- [x] **Body view modes**: JSON (syntax-highlighted code, line numbers), Tree (collapsible JSON tree with **right-click "Copy path"**), **Preview** (HTML rendered as readable text), **Events** (structured SSE log), Raw
+- [x] **Server-Sent Events (SSE)** — streaming support for LLM / event-stream APIs with live Events view (auto-scroll, per-event timestamps, JSON pretty-print)
+- [x] **Cancel button** — Send flips to Cancel while in flight; instantly aborts the tokio task
+- [x] **Illustrated failed/cancelled state** — network failure / TLS / cancel screens with detail pill instead of raw text
 - [x] Find-in-body, copy-body, **save-response-to-file**
 - [x] Response info chips (status / time / size) **inline** with the Body/Headers tab row; tooltips for size & time breakdowns
 - [x] Loading spinner; readable error chains (no more opaque "builder error")
@@ -534,29 +567,33 @@ Networking & safety
 - [x] **Reused `reqwest::Client` + `tokio::Runtime`** across sends — no per-request spinup cost
 - [x] **Cookie jar (per-environment)** — `Set-Cookie` parsed, host/path-matched on next send, expiry-aware
 
+UI
+- [x] **Phosphor icon font** — 1,200+ tintable icons rendered as font glyphs (replaces every hand-drawn painter icon)
+- [x] **Styled hint text** — dim, italic-free placeholders in all TextEdits so `Key`/`Value`/`Description` no longer look like real data
+
 Platform
 - [x] macOS + Linux one-line installer (`install.sh`); auto-detects platform
 - [x] Universal macOS DMG (Apple Silicon + Intel) and Linux x86_64 tarball built by GitHub Actions
-- [x] **Native macOS NSMenu bar** (App / File / View / Request / Help) with ⌘P, ⌘⏎, ⇧⌘C accelerators
+- [x] **Native macOS NSMenu bar** (App / File / View / Request / Help) with ⌘N, ⌘W, ⌘P, ⌘⏎, ⇧⌘C accelerators
 - [x] Custom **About modal** with creator credit + Contribute / Report-issue links
 
-**In progress / planned:**
+**On the v1.0 pathway:**
 
-- [ ] **WebSocket testing** — needs a separate connection lifecycle and message-log UI;
-      plan is to add a `RequestKind::WebSocket` mode using `tokio-tungstenite` with a
-      send box + scrolling message log per request.
 - [ ] **OAuth 2.0** flows (Authorization Code + PKCE, Client Credentials, refresh
-      token). Probably the highest-impact next addition for users hitting auth-gated
-      APIs; tokens would slot directly into the existing env / extractor system.
-- [ ] **Pre-request scripts** — full JS-style scripts via Rhai or Boa; the lightweight
-      post-response extractors + assertions cover ~80% of what users reach for, but
-      pre-request transformations need an embedded scripting engine.
-- [ ] **Server-Sent Events (SSE)** support — handy for the LLM-streaming endpoints
-      that have become common.
-- [ ] **Response diff** — "send twice, diff me" between two recent responses; useful
-      regression-test feature unique to this app.
-- [ ] **Light theme** — the dark theme is opinionated; a parallel light palette would
-      be straightforward but require touching every color constant.
+      token). Highest-impact remaining feature; tokens slot directly into the env
+      system.
+- [ ] **Light theme** — parallel palette behind a Settings toggle. The dark default
+      stays unchanged.
+- [ ] **Response diff** — "send twice, diff me" between two recent responses.
+- [ ] **⇧⌘P actions palette** — ⌘P finds requests; ⇧⌘P triggers app actions
+      (toggle snippet panel, duplicate tab, clear history, etc.).
+
+**Post-1.0:**
+
+- [ ] **WebSocket testing** — separate connection lifecycle + per-request message log.
+- [ ] **Pre-request scripts** — Rhai/Boa scripting engine for transformations before send.
+- [ ] **Windows builds** — CI + installer parity with macOS/Linux.
+- [ ] **Collection runner** — run a folder as a sequence, pass extracted vars forward.
 
 ---
 
@@ -585,8 +622,9 @@ with a documented migration path:
   `install.sh` (`VERSION`, `SKIP_QUARANTINE_STRIP`, `RUSTY_REPO`).
 - **Import / export formats** — JSON / YAML round-trip, Postman
   Collection v2.1 import.
-- **Public macOS menu shortcuts** — `⌘⏎` Send, `⌘P` Command palette,
-  `⌘K` Sidebar search, `⇧⌘C` toggle snippet panel.
+- **Public macOS menu shortcuts** — `⌘⏎` Send, `⌘N` New request,
+  `⌘W` Close tab, `⌘D` Duplicate tab, `⌘P` Command palette,
+  `⌘K` Sidebar search, `⌘S` Save draft, `⇧⌘C` toggle snippet panel.
 
 Anything *not* in this list (UI layout, internal module structure, exact
 binary size, theme colors, syntax-highlight palette, behind-the-scenes

--- a/src/actions.rs
+++ b/src/actions.rs
@@ -1,0 +1,116 @@
+//! Actions palette — the counterpart to `command_palette` (⌘P).
+//! ⌘P finds requests; ⇧⌘P triggers app actions (toggle panel,
+//! duplicate tab, clear history, etc.). Actions are a fixed enum
+//! so they're strongly-typed at the call site, self-document their
+//! labels + keywords, and can advertise keyboard shortcuts in the
+//! palette row.
+
+/// Every action the ⇧⌘P palette can dispatch. Kept small enough to
+/// fit on one screen; add new entries as the app grows.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PaletteAction {
+    NewRequest,
+    DuplicateTab,
+    CloseTab,
+    TogglePin,
+    SaveDraft,
+    CopyAsCurl,
+    ToggleSnippetPanel,
+    OpenEnvironments,
+    OpenSettings,
+    PasteCurl,
+    ImportCollection,
+    ExportJson,
+    ExportYaml,
+    ClearHistory,
+    ToggleSidebarHistory,
+    ShowAbout,
+}
+
+impl PaletteAction {
+    /// Every action in palette order. Ordering matters — the first
+    /// match for a given fuzzy query wins the initial selection.
+    pub const ALL: &'static [Self] = &[
+        Self::NewRequest,
+        Self::DuplicateTab,
+        Self::CloseTab,
+        Self::TogglePin,
+        Self::SaveDraft,
+        Self::CopyAsCurl,
+        Self::ToggleSnippetPanel,
+        Self::OpenEnvironments,
+        Self::OpenSettings,
+        Self::PasteCurl,
+        Self::ImportCollection,
+        Self::ExportJson,
+        Self::ExportYaml,
+        Self::ClearHistory,
+        Self::ToggleSidebarHistory,
+        Self::ShowAbout,
+    ];
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::NewRequest => "New request",
+            Self::DuplicateTab => "Duplicate tab",
+            Self::CloseTab => "Close tab",
+            Self::TogglePin => "Toggle pin tab",
+            Self::SaveDraft => "Save draft to folder…",
+            Self::CopyAsCurl => "Copy as cURL",
+            Self::ToggleSnippetPanel => "Toggle code snippet panel",
+            Self::OpenEnvironments => "Open environments…",
+            Self::OpenSettings => "Open settings…",
+            Self::PasteCurl => "Paste cURL command…",
+            Self::ImportCollection => "Import collection file…",
+            Self::ExportJson => "Export all as JSON…",
+            Self::ExportYaml => "Export all as YAML…",
+            Self::ClearHistory => "Clear history",
+            Self::ToggleSidebarHistory => "Toggle sidebar History / Collections view",
+            Self::ShowAbout => "About Rusty Requester",
+        }
+    }
+
+    /// Extra search keywords — things the user might type that aren't
+    /// in the label. Kept lowercase; the palette searches on
+    /// `label + keywords`.
+    pub fn keywords(&self) -> &'static str {
+        match self {
+            Self::NewRequest => "create add tab",
+            Self::DuplicateTab => "clone copy tab",
+            Self::CloseTab => "close window",
+            Self::TogglePin => "pin unpin sticky",
+            Self::SaveDraft => "save persist folder collection",
+            Self::CopyAsCurl => "curl command line shell",
+            Self::ToggleSnippetPanel => "code panel side python javascript fetch httpie",
+            Self::OpenEnvironments => "env variables vars",
+            Self::OpenSettings => "preferences timeout proxy tls",
+            Self::PasteCurl => "curl import clipboard",
+            Self::ImportCollection => "import postman json yaml",
+            Self::ExportJson => "export backup json",
+            Self::ExportYaml => "export backup yaml",
+            Self::ClearHistory => "delete wipe log",
+            Self::ToggleSidebarHistory => "switch toggle sidebar history collections",
+            Self::ShowAbout => "about version credit help",
+        }
+    }
+
+    /// Keyboard shortcut display, right-aligned in the palette row.
+    /// `None` = no shortcut (rare, but some actions are palette-only).
+    pub fn shortcut(&self) -> Option<&'static str> {
+        match self {
+            Self::NewRequest => Some("⌘N"),
+            Self::DuplicateTab => Some("⌘D"),
+            Self::CloseTab => Some("⌘W"),
+            Self::SaveDraft => Some("⌘S"),
+            Self::ToggleSnippetPanel => Some("⇧⌘C"),
+            Self::OpenSettings => Some("⌘,"),
+            _ => None,
+        }
+    }
+
+    /// Haystack string used by the fuzzy matcher (lowercase,
+    /// `label + " " + keywords`).
+    pub fn haystack_lc(&self) -> String {
+        format!("{} {}", self.label(), self.keywords()).to_lowercase()
+    }
+}

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,0 +1,195 @@
+//! Minimal line-level diff — produces a unified-diff-ish view of two
+//! response bodies. Good enough for "send twice, compare" on JSON /
+//! text responses; not trying to be `git diff`.
+//!
+//! Algorithm: longest common subsequence (LCS) over line arrays, then
+//! walk back to produce a flat list of `(Op, line)` pairs. O(n·m)
+//! time and memory — fine for the response-size range we care about
+//! (truncated at `max_body_mb`). For 100k+ line bodies a patience /
+//! histogram diff would be faster, but that's outside the 90% case
+//! and avoids the extra dependency.
+
+use std::fmt::Write;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Op {
+    Same,
+    Added,
+    Removed,
+}
+
+#[derive(Clone, Debug)]
+pub struct DiffLine {
+    pub op: Op,
+    pub text: String,
+    /// Line number in the `before` body, if applicable (Same / Removed).
+    /// Exposed so a future gutter renderer can show 1:1 line numbers
+    /// — not currently read by the UI.
+    #[allow(dead_code)]
+    pub lhs: Option<usize>,
+    /// Line number in the `after` body, if applicable (Same / Added).
+    #[allow(dead_code)]
+    pub rhs: Option<usize>,
+}
+
+/// Diff two strings as line arrays.
+pub fn diff_lines(before: &str, after: &str) -> Vec<DiffLine> {
+    let a: Vec<&str> = before.lines().collect();
+    let b: Vec<&str> = after.lines().collect();
+    let n = a.len();
+    let m = b.len();
+
+    // Build LCS length table. Rows = a.len()+1, Cols = b.len()+1.
+    // Indexed loops are clearer here than enumerate — the table is
+    // 1-indexed relative to the input arrays so `i + 1` / `j + 1`
+    // references read naturally.
+    #[allow(clippy::needless_range_loop)]
+    let mut lcs: Vec<Vec<u32>> = vec![vec![0; m + 1]; n + 1];
+    #[allow(clippy::needless_range_loop)]
+    for i in 0..n {
+        for j in 0..m {
+            lcs[i + 1][j + 1] = if a[i] == b[j] {
+                lcs[i][j] + 1
+            } else {
+                lcs[i][j + 1].max(lcs[i + 1][j])
+            };
+        }
+    }
+
+    // Walk the table to emit ops in reverse, then flip.
+    let mut out: Vec<DiffLine> = Vec::with_capacity(n + m);
+    let (mut i, mut j) = (n, m);
+    while i > 0 && j > 0 {
+        if a[i - 1] == b[j - 1] {
+            out.push(DiffLine {
+                op: Op::Same,
+                text: a[i - 1].to_string(),
+                lhs: Some(i),
+                rhs: Some(j),
+            });
+            i -= 1;
+            j -= 1;
+        } else if lcs[i - 1][j] >= lcs[i][j - 1] {
+            out.push(DiffLine {
+                op: Op::Removed,
+                text: a[i - 1].to_string(),
+                lhs: Some(i),
+                rhs: None,
+            });
+            i -= 1;
+        } else {
+            out.push(DiffLine {
+                op: Op::Added,
+                text: b[j - 1].to_string(),
+                lhs: None,
+                rhs: Some(j),
+            });
+            j -= 1;
+        }
+    }
+    while i > 0 {
+        out.push(DiffLine {
+            op: Op::Removed,
+            text: a[i - 1].to_string(),
+            lhs: Some(i),
+            rhs: None,
+        });
+        i -= 1;
+    }
+    while j > 0 {
+        out.push(DiffLine {
+            op: Op::Added,
+            text: b[j - 1].to_string(),
+            lhs: None,
+            rhs: Some(j),
+        });
+        j -= 1;
+    }
+    out.reverse();
+    out
+}
+
+/// Summary counts for a diff — used as the "+A -B" badge next to the
+/// Diff pill.
+pub fn summarize(diff: &[DiffLine]) -> (usize, usize) {
+    let mut added = 0usize;
+    let mut removed = 0usize;
+    for l in diff {
+        match l.op {
+            Op::Added => added += 1,
+            Op::Removed => removed += 1,
+            Op::Same => {}
+        }
+    }
+    (added, removed)
+}
+
+/// Render a diff as a flat text block (used as fallback for
+/// monospace TextEdit rendering). The UI layer has a richer
+/// row-based renderer; this stays around for copy-as-plaintext.
+#[allow(dead_code)]
+pub fn to_plain(diff: &[DiffLine]) -> String {
+    let mut out = String::new();
+    for l in diff {
+        let prefix = match l.op {
+            Op::Same => ' ',
+            Op::Added => '+',
+            Op::Removed => '-',
+        };
+        let _ = writeln!(out, "{}{}", prefix, l.text);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identical_inputs_all_same() {
+        let d = diff_lines("a\nb\nc", "a\nb\nc");
+        assert_eq!(d.len(), 3);
+        assert!(d.iter().all(|l| l.op == Op::Same));
+        assert_eq!(summarize(&d), (0, 0));
+    }
+
+    #[test]
+    fn pure_addition() {
+        let d = diff_lines("", "x\ny");
+        assert_eq!(summarize(&d), (2, 0));
+        assert_eq!(d[0].op, Op::Added);
+        assert_eq!(d[1].op, Op::Added);
+    }
+
+    #[test]
+    fn pure_removal() {
+        let d = diff_lines("x\ny", "");
+        assert_eq!(summarize(&d), (0, 2));
+    }
+
+    #[test]
+    fn middle_change() {
+        let d = diff_lines("a\nb\nc", "a\nB\nc");
+        // Two variants are valid: (remove b, add B) or interleave — the
+        // LCS walk produces one deterministic order. Summary is what we
+        // care about.
+        assert_eq!(summarize(&d), (1, 1));
+        // Line numbering: `a` and `c` are Same; the changed pair keeps
+        // the before/after indices.
+        assert_eq!(d.first().unwrap().op, Op::Same);
+        assert_eq!(d.last().unwrap().op, Op::Same);
+    }
+
+    #[test]
+    fn line_numbers_track() {
+        let d = diff_lines("a\nb\nc", "a\nc");
+        // `a` same (1,1), `b` removed (2,-), `c` same (3,2).
+        let same_a = d.iter().find(|l| l.text == "a").unwrap();
+        assert_eq!(same_a.lhs, Some(1));
+        assert_eq!(same_a.rhs, Some(1));
+        let removed_b = d.iter().find(|l| l.text == "b").unwrap();
+        assert_eq!(removed_b.op, Op::Removed);
+        assert_eq!(removed_b.lhs, Some(2));
+        assert_eq!(removed_b.rhs, None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
+mod actions;
 mod assertion;
 mod cookies;
+mod diff;
 mod extract;
 mod html_preview;
 mod icon;
@@ -55,6 +57,12 @@ struct ApiClient {
     response_download_ms: u64,
     response_total_ms: u64,
     is_loading: bool,
+
+    /// Previous response body, retained just long enough to power the
+    /// **Diff** view. Snapshot taken right before a new response
+    /// overwrites `response_text`; `None` means there's no prior
+    /// response to compare against.
+    previous_response_text: Option<String>,
 
     editing_url: String,
     editing_body: String,
@@ -124,6 +132,10 @@ struct ApiClient {
     pending_import: bool,
     pending_export_json: bool,
     pending_export_yaml: bool,
+    /// Text to copy to the clipboard at the top of the next frame.
+    /// Used by palette-dispatched actions (e.g. Copy as cURL) that
+    /// don't have direct access to `egui::Context` for `ctx.copy_text`.
+    pending_clipboard: Option<String>,
 
     /// Open "save draft" modal state.
     save_draft_open: bool,
@@ -191,6 +203,16 @@ struct ApiClient {
     palette_query: String,
     palette_selected: usize,
     palette_focus_pending: bool,
+
+    // --- Actions palette (⇧⌘P) ---------------------------------------
+    /// Parallel palette for triggering app actions (toggle snippet
+    /// panel, duplicate tab, clear history, etc.) rather than
+    /// navigating to requests. Shares the same overlay chrome as the
+    /// command palette but dispatches into `run_action` on Enter.
+    show_actions_palette: bool,
+    actions_palette_query: String,
+    actions_palette_selected: usize,
+    actions_palette_focus_pending: bool,
     /// Have we installed the macOS NSMenu yet? We defer the install
     /// to the first `update()` frame because doing it before
     /// `eframe::run_native` lets winit overwrite our menu with its
@@ -239,6 +261,7 @@ impl Default for ApiClient {
             response_waiting_ms: 0,
             response_download_ms: 0,
             response_total_ms: 0,
+            previous_response_text: None,
             response_headers: vec![],
             is_loading: false,
             editing_url: String::new(),
@@ -280,6 +303,7 @@ impl Default for ApiClient {
             pending_import: false,
             pending_export_json: false,
             pending_export_yaml: false,
+            pending_clipboard: None,
             save_draft_open: false,
             save_draft_tab_idx: None,
             save_draft_target_path: Vec::new(),
@@ -300,6 +324,10 @@ impl Default for ApiClient {
             viewing_folder_id: None,
             editing_folder_desc: String::new(),
             show_command_palette: false,
+            show_actions_palette: false,
+            actions_palette_query: String::new(),
+            actions_palette_selected: 0,
+            actions_palette_focus_pending: false,
             palette_query: String::new(),
             palette_selected: 0,
             palette_focus_pending: false,
@@ -439,6 +467,12 @@ impl ApiClient {
         self.commit_editing();
         let env = self.active_environment().cloned();
         if let Some(request) = self.get_current_request() {
+            // Snapshot the previous response body for the Diff view,
+            // but only if it looks like a real response (not the
+            // "Loading..." placeholder or an empty slate).
+            if !self.response_text.is_empty() && self.response_text != "Loading..." {
+                self.previous_response_text = Some(self.response_text.clone());
+            }
             self.is_loading = true;
             self.response_text = "Loading...".to_string();
             self.response_status = "Sending request...".to_string();
@@ -705,6 +739,9 @@ impl ApiClient {
             // Capture method for history entry too
             let _ = r.method;
         }
+        // Diff snapshot is request-scoped — don't leak a previous
+        // request's body into a different request's Diff view.
+        self.previous_response_text = None;
     }
 
     fn show_toast(&mut self, msg: impl Into<String>) {
@@ -954,6 +991,97 @@ impl ApiClient {
         self.load_request_for_editing();
         self.save_state();
         self.show_toast("Tab duplicated");
+    }
+
+    /// Dispatch a `PaletteAction` — the single entry point the
+    /// actions palette uses on Enter/click. Most branches reuse
+    /// existing helpers; a few translate a menu-dispatch event into
+    /// the equivalent state flip.
+    fn run_action(&mut self, action: actions::PaletteAction) {
+        use actions::PaletteAction as A;
+        match action {
+            A::NewRequest => self.new_draft_request(),
+            A::DuplicateTab => {
+                if let Some(idx) = self.active_tab_index() {
+                    self.duplicate_tab(idx);
+                }
+            }
+            A::CloseTab => {
+                if let Some(idx) = self.active_tab_index() {
+                    self.close_tab(idx);
+                }
+            }
+            A::TogglePin => {
+                if let Some(idx) = self.active_tab_index() {
+                    if let Some(tab) = self.state.open_tabs.get_mut(idx) {
+                        tab.pinned = !tab.pinned;
+                        self.save_state();
+                    }
+                }
+            }
+            A::SaveDraft => {
+                if let Some(idx) = self.active_tab_index() {
+                    if self.state.open_tabs[idx].folder_path.is_empty() {
+                        self.begin_save_draft(idx);
+                    } else {
+                        self.show_toast("Already saved");
+                    }
+                }
+            }
+            A::CopyAsCurl => {
+                if let Some(req) = self.get_current_request() {
+                    let s = curl::to_curl(&req);
+                    // egui's Context::copy_text is frame-scoped; show a
+                    // toast and use arboard-like behavior via ctx next
+                    // frame would be ideal, but render_toast is the
+                    // immediate confirmation users expect.
+                    // Use egui's clipboard by writing to the context.
+                    self.pending_clipboard = Some(s);
+                    self.show_toast("Copied cURL to clipboard");
+                }
+            }
+            A::ToggleSnippetPanel => self.show_snippet_panel = !self.show_snippet_panel,
+            A::OpenEnvironments => {
+                self.show_env_modal = true;
+                if self.selected_env_for_edit.is_none() {
+                    self.selected_env_for_edit =
+                        self.state.environments.first().map(|e| e.id.clone());
+                }
+            }
+            A::OpenSettings => {
+                self.editing_settings = self.state.settings.clone();
+                self.show_settings_modal = true;
+            }
+            A::PasteCurl => {
+                self.show_paste_modal = true;
+                self.paste_curl_text.clear();
+                self.paste_error.clear();
+            }
+            A::ImportCollection => self.pending_import = true,
+            A::ExportJson => self.pending_export_json = true,
+            A::ExportYaml => self.pending_export_yaml = true,
+            A::ClearHistory => {
+                self.state.history.clear();
+                self.save_state();
+                self.show_toast("History cleared");
+            }
+            A::ToggleSidebarHistory => {
+                self.sidebar_view = match self.sidebar_view {
+                    SidebarView::Collections => SidebarView::History,
+                    SidebarView::History => SidebarView::Collections,
+                };
+            }
+            A::ShowAbout => self.show_about_modal = true,
+        }
+    }
+
+    /// Tab index of the active tab, or `None` if no request is open.
+    fn active_tab_index(&self) -> Option<usize> {
+        let req_id = self.selected_request_id.as_ref()?;
+        self.state
+            .open_tabs
+            .iter()
+            .position(|t| &t.request_id == req_id)
     }
 
     fn prune_stale_tabs(&mut self) {
@@ -1218,28 +1346,44 @@ impl eframe::App for ApiClient {
             self.pending_export_yaml = false;
             self.do_export_all(io::Format::Yaml);
         }
+        if let Some(text) = self.pending_clipboard.take() {
+            ctx.copy_text(text);
+        }
 
-        let (cmd_enter, cmd_k, cmd_p, cmd_s, cmd_n, cmd_w, cmd_d, f2, arrow_up, arrow_down) = ctx
-            .input(|i| {
-                (
-                    i.modifiers.command && i.key_pressed(egui::Key::Enter),
-                    i.modifiers.command && i.key_pressed(egui::Key::K),
-                    i.modifiers.command && i.key_pressed(egui::Key::P),
-                    i.modifiers.command && i.key_pressed(egui::Key::S),
-                    i.modifiers.command && i.key_pressed(egui::Key::N),
-                    i.modifiers.command && i.key_pressed(egui::Key::W),
-                    i.modifiers.command && i.key_pressed(egui::Key::D),
-                    i.key_pressed(egui::Key::F2),
-                    !i.modifiers.command && !i.modifiers.alt && i.key_pressed(egui::Key::ArrowUp),
-                    !i.modifiers.command && !i.modifiers.alt && i.key_pressed(egui::Key::ArrowDown),
-                )
-            });
+        let (
+            cmd_enter,
+            cmd_k,
+            cmd_p,
+            cmd_shift_p,
+            cmd_s,
+            cmd_n,
+            cmd_w,
+            cmd_d,
+            f2,
+            arrow_up,
+            arrow_down,
+        ) = ctx.input(|i| {
+            (
+                i.modifiers.command && i.key_pressed(egui::Key::Enter),
+                i.modifiers.command && i.key_pressed(egui::Key::K),
+                i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::P),
+                i.modifiers.command && i.modifiers.shift && i.key_pressed(egui::Key::P),
+                i.modifiers.command && i.key_pressed(egui::Key::S),
+                i.modifiers.command && i.key_pressed(egui::Key::N),
+                i.modifiers.command && i.key_pressed(egui::Key::W),
+                i.modifiers.command && i.key_pressed(egui::Key::D),
+                i.key_pressed(egui::Key::F2),
+                !i.modifiers.command && !i.modifiers.alt && i.key_pressed(egui::Key::ArrowUp),
+                !i.modifiers.command && !i.modifiers.alt && i.key_pressed(egui::Key::ArrowDown),
+            )
+        });
         // Arrow navigation is gated on "no widget wants keyboard
         // input" — so typing in a TextEdit, Body editor, or search
         // box isn't hijacked. When nothing's focused, ↑/↓ step
         // through the flat request list in the sidebar.
         let can_arrow_nav = !ctx.wants_keyboard_input()
             && !self.show_command_palette
+            && !self.show_actions_palette
             && !self.show_env_modal
             && !self.show_settings_modal
             && !self.show_paste_modal
@@ -1295,6 +1439,12 @@ impl eframe::App for ApiClient {
             self.palette_query.clear();
             self.palette_selected = 0;
             self.palette_focus_pending = true;
+        }
+        if cmd_shift_p {
+            self.show_actions_palette = true;
+            self.actions_palette_query.clear();
+            self.actions_palette_selected = 0;
+            self.actions_palette_focus_pending = true;
         }
         // Cmd/Ctrl+S — if the active tab is a draft, open the Save-draft
         // modal to pick a destination collection. Saved requests are
@@ -1435,6 +1585,7 @@ impl eframe::App for ApiClient {
         self.render_confirm_close_draft(ctx);
         self.render_about_modal(ctx);
         self.render_command_palette(ctx);
+        self.render_actions_palette(ctx);
         self.render_toast(ctx);
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -299,7 +299,7 @@ pub struct Folder {
     pub subfolders: Vec<Folder>,
     /// Free-text description shown on the collection/folder overview
     /// page. Multiline; can be empty.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
 }
 
@@ -395,7 +395,7 @@ pub struct StoredCookie {
     pub value: String,
     /// Lowercase host match — "example.com" matches "api.example.com"
     /// and "example.com" itself. Empty = match the request's exact host.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub domain: String,
     /// URL-prefix match, default "/".
     #[serde(default = "default_cookie_path")]
@@ -406,10 +406,15 @@ pub struct StoredCookie {
     pub expires: Option<i64>,
     /// Whether the cookie was marked `Secure` — we still send it on
     /// plain http (dev APIs), but we track the flag.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub secure: bool,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub http_only: bool,
+}
+
+#[inline]
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 fn default_cookie_path() -> String {
@@ -439,7 +444,7 @@ pub struct OpenTab {
     pub request_id: String,
     /// Pinned tabs are skipped by ⌘W and "Close others" / "Close all"
     /// so they can be kept around as persistent references.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "is_false")]
     pub pinned: bool,
 }
 
@@ -476,6 +481,8 @@ pub enum ResponseTab {
 ///   • `Events` — structured SSE event log with per-event rows.
 ///     Only offered when the response Content-Type is
 ///     `text/event-stream`.
+///   • `Diff` — line-diff against the previous response body. Only
+///     offered when a prior response exists for the same request.
 ///   • `Raw` — verbatim text, no formatting.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum BodyView {
@@ -483,6 +490,7 @@ pub enum BodyView {
     Tree,
     Preview,
     Events,
+    Diff,
     Raw,
 }
 

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1500,6 +1500,170 @@ impl ApiClient {
         }
     }
 
+    /// Actions palette (⇧⌘P) — the counterpart to `render_command_palette`.
+    /// Same overlay chrome, but the list is `actions::PaletteAction::ALL`
+    /// and Enter dispatches through `run_action` instead of opening a
+    /// request.
+    pub(crate) fn render_actions_palette(&mut self, ctx: &egui::Context) {
+        if !self.show_actions_palette {
+            return;
+        }
+        use crate::actions::PaletteAction;
+        let query_lc = self.actions_palette_query.to_lowercase();
+        let matches: Vec<&PaletteAction> = PaletteAction::ALL
+            .iter()
+            .filter(|a| {
+                if query_lc.is_empty() {
+                    true
+                } else {
+                    fuzzy_contains(&a.haystack_lc(), &query_lc)
+                }
+            })
+            .collect();
+
+        if self.actions_palette_selected >= matches.len() {
+            self.actions_palette_selected = matches.len().saturating_sub(1);
+        }
+
+        let (enter, esc, arrow_up, arrow_down) = ctx.input(|i| {
+            (
+                i.key_pressed(egui::Key::Enter),
+                i.key_pressed(egui::Key::Escape),
+                i.key_pressed(egui::Key::ArrowUp),
+                i.key_pressed(egui::Key::ArrowDown),
+            )
+        });
+        if esc {
+            self.show_actions_palette = false;
+            return;
+        }
+        if arrow_down && !matches.is_empty() {
+            self.actions_palette_selected = (self.actions_palette_selected + 1) % matches.len();
+        }
+        if arrow_up && !matches.is_empty() {
+            self.actions_palette_selected = if self.actions_palette_selected == 0 {
+                matches.len() - 1
+            } else {
+                self.actions_palette_selected - 1
+            };
+        }
+        let mut activate: Option<PaletteAction> = None;
+        if enter {
+            if let Some(a) = matches.get(self.actions_palette_selected) {
+                activate = Some(**a);
+            }
+        }
+
+        // Dim backdrop matches the command palette for visual parity.
+        let screen = ctx.screen_rect();
+        ctx.layer_painter(egui::LayerId::new(
+            egui::Order::Middle,
+            egui::Id::new("actions_palette_backdrop"),
+        ))
+        .rect_filled(
+            screen,
+            egui::Rounding::ZERO,
+            egui::Color32::from_black_alpha(140),
+        );
+
+        let mut open = true;
+        egui::Window::new(
+            egui::RichText::new("ACTIONS")
+                .size(11.0)
+                .strong()
+                .color(C_MUTED),
+        )
+        .open(&mut open)
+        .collapsible(false)
+        .resizable(false)
+        .fixed_size(egui::vec2(560.0, 420.0))
+        .anchor(egui::Align2::CENTER_TOP, egui::vec2(0.0, 80.0))
+        .show(ctx, |ui| {
+            let query_resp = ui.add(
+                egui::TextEdit::singleline(&mut self.actions_palette_query)
+                    .hint_text("Run an action…")
+                    .desired_width(f32::INFINITY)
+                    .font(egui::TextStyle::Body),
+            );
+            if self.actions_palette_focus_pending {
+                self.actions_palette_focus_pending = false;
+                query_resp.request_focus();
+            }
+            ui.add_space(6.0);
+            ui.label(
+                egui::RichText::new(format!(
+                    "{} action{}",
+                    matches.len(),
+                    if matches.len() == 1 { "" } else { "s" }
+                ))
+                .size(10.5)
+                .color(C_MUTED),
+            );
+            ui.separator();
+
+            egui::ScrollArea::vertical()
+                .id_salt("actions_palette_scroll")
+                .max_height(320.0)
+                .auto_shrink([false, false])
+                .show(ui, |ui| {
+                    for (i, a) in matches.iter().enumerate() {
+                        let is_sel = i == self.actions_palette_selected;
+                        let (rect, resp) = ui.allocate_exact_size(
+                            egui::vec2(ui.available_width(), 32.0),
+                            egui::Sense::click(),
+                        );
+                        if ui.is_rect_visible(rect) {
+                            let bg = if is_sel {
+                                C_ACCENT.linear_multiply(0.18)
+                            } else if resp.hovered() {
+                                C_ELEVATED
+                            } else {
+                                egui::Color32::TRANSPARENT
+                            };
+                            ui.painter()
+                                .rect_filled(rect, egui::Rounding::same(5.0), bg);
+                            ui.painter().text(
+                                egui::pos2(rect.left() + 14.0, rect.center().y),
+                                egui::Align2::LEFT_CENTER,
+                                a.label(),
+                                egui::FontId::new(13.0, egui::FontFamily::Proportional),
+                                C_TEXT,
+                            );
+                            if let Some(sc) = a.shortcut() {
+                                ui.painter().text(
+                                    egui::pos2(rect.right() - 14.0, rect.center().y),
+                                    egui::Align2::RIGHT_CENTER,
+                                    sc,
+                                    egui::FontId::new(11.0, egui::FontFamily::Monospace),
+                                    C_MUTED,
+                                );
+                            }
+                        }
+                        let resp = resp.on_hover_cursor(egui::CursorIcon::PointingHand);
+                        if resp.clicked() {
+                            activate = Some(**a);
+                        }
+                    }
+                });
+
+            ui.add_space(4.0);
+            ui.horizontal(|ui| {
+                ui.label(
+                    egui::RichText::new("↑ ↓  navigate    Enter  run    Esc  dismiss")
+                        .size(10.5)
+                        .color(C_MUTED),
+                );
+            });
+        });
+        if !open {
+            self.show_actions_palette = false;
+        }
+        if let Some(action) = activate {
+            self.show_actions_palette = false;
+            self.run_action(action);
+        }
+    }
+
     pub(crate) fn render_toast(&mut self, ctx: &egui::Context) {
         let Some((msg, ttl)) = self.toast.clone() else {
             return;

--- a/src/ui/response.rs
+++ b/src/ui/response.rs
@@ -133,6 +133,101 @@ impl ApiClient {
             });
     }
 
+    /// Response diff view — unified `+/-` line-diff between the
+    /// previous response body and the current one. Added lines are
+    /// green with a `+` gutter, removed lines red with `-`, same
+    /// lines muted. Header summary shows `+A −B`.
+    fn render_diff_view(&mut self, ui: &mut egui::Ui) {
+        let Some(before) = self.previous_response_text.as_deref() else {
+            ui.vertical_centered(|ui| {
+                ui.add_space(40.0);
+                ui.label(
+                    egui::RichText::new(
+                        "Send the request again to see a diff against this response.",
+                    )
+                    .size(13.0)
+                    .color(C_MUTED),
+                );
+            });
+            return;
+        };
+        let after = self.response_text.as_str();
+        let d = crate::diff::diff_lines(before, after);
+        let (added, removed) = crate::diff::summarize(&d);
+
+        ui.horizontal(|ui| {
+            ui.label(
+                egui::RichText::new(format!("+{}", added))
+                    .color(C_GREEN)
+                    .strong()
+                    .monospace()
+                    .size(12.0),
+            );
+            ui.add_space(6.0);
+            ui.label(
+                egui::RichText::new(format!("−{}", removed))
+                    .color(C_RED)
+                    .strong()
+                    .monospace()
+                    .size(12.0),
+            );
+            ui.add_space(12.0);
+            ui.label(
+                egui::RichText::new("vs previous response")
+                    .color(C_MUTED)
+                    .size(11.0),
+            );
+        });
+        ui.add_space(4.0);
+
+        if added == 0 && removed == 0 {
+            ui.label(
+                egui::RichText::new("No differences — the response bodies are identical.")
+                    .color(C_MUTED)
+                    .size(12.0),
+            );
+            return;
+        }
+
+        let font = egui::FontId::monospace(12.0);
+        egui::ScrollArea::vertical()
+            .id_salt("diff_scroll")
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                for line in &d {
+                    let (prefix, fg, bg) = match line.op {
+                        crate::diff::Op::Same => (" ", C_TEXT, egui::Color32::TRANSPARENT),
+                        crate::diff::Op::Added => ("+", C_GREEN, C_GREEN.linear_multiply(0.12)),
+                        crate::diff::Op::Removed => ("−", C_RED, C_RED.linear_multiply(0.12)),
+                    };
+                    let row_h = 16.0;
+                    let (rect, _) = ui.allocate_exact_size(
+                        egui::vec2(ui.available_width(), row_h),
+                        egui::Sense::hover(),
+                    );
+                    if ui.is_rect_visible(rect) {
+                        if bg != egui::Color32::TRANSPARENT {
+                            ui.painter().rect_filled(rect, egui::Rounding::ZERO, bg);
+                        }
+                        ui.painter().text(
+                            egui::pos2(rect.left() + 4.0, rect.center().y),
+                            egui::Align2::LEFT_CENTER,
+                            prefix,
+                            font.clone(),
+                            fg,
+                        );
+                        ui.painter().text(
+                            egui::pos2(rect.left() + 18.0, rect.center().y),
+                            egui::Align2::LEFT_CENTER,
+                            &line.text,
+                            font.clone(),
+                            fg,
+                        );
+                    }
+                }
+            });
+    }
+
     /// Error / cancel state — replaces the code editor with a
     /// centered illustration, status headline, error detail pill,
     /// and a helper hint line. Modeled after Postman's "Could not
@@ -263,6 +358,11 @@ impl ApiClient {
                 if is_html_body {
                     body_view_pill(ui, &mut view, BodyView::Preview, "Preview");
                 }
+                // Diff pill surfaces only when a prior response exists.
+                let has_diff_snapshot = self.previous_response_text.is_some();
+                if has_diff_snapshot {
+                    body_view_pill(ui, &mut view, BodyView::Diff, "Diff");
+                }
                 body_view_pill(ui, &mut view, BodyView::Raw, "Raw");
                 // If the user had a pill selected that no longer
                 // applies to this response, fall back to a sensible
@@ -275,6 +375,9 @@ impl ApiClient {
                 }
                 if is_sse_body && matches!(view, BodyView::Json | BodyView::Tree) {
                     view = BodyView::Events;
+                }
+                if matches!(view, BodyView::Diff) && !has_diff_snapshot {
+                    view = BodyView::Raw;
                 }
                 self.body_view = view;
                 if matches!(self.body_view, BodyView::Tree) && is_json_body {
@@ -572,6 +675,9 @@ impl ApiClient {
                                 }
                                 BodyView::Events => {
                                     self.render_events_view(ui);
+                                }
+                                BodyView::Diff => {
+                                    self.render_diff_view(ui);
                                 }
                                 BodyView::Raw => {
                                     ui.add_sized(


### PR DESCRIPTION
- **Refresh README and CHANGELOG for v0.6–v0.10 features**
- **Add ⌘⇧P actions palette (16 actions, keyboard-driven)**
- **Add response diff view — line-level before/after comparison**
- **Refresh README and CHANGELOG for v0.6–v0.10 features**
