### PR TITLE
feat/oauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,36 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
-## Unreleased — Light theme
+## Unreleased — OAuth 2.0
+
+### Added
+- **OAuth 2.0 Authorization Code + PKCE.** New `Auth::OAuth2` variant
+  alongside Bearer / Basic. Full in-app flow — click **Get New
+  Token** in the Auth tab, the app opens your provider's authorize
+  URL in your default browser, spins up a loopback listener on a
+  random `127.0.0.1:<port>`, parses the redirect, exchanges the
+  code for a token via the provider's `token_url`. Access token +
+  refresh token + expiry get cached on the request; subsequent
+  sends inject `Authorization: Bearer <token>` automatically. The
+  Auth tab shows a live status badge (valid / refreshing soon /
+  expired) and a masked preview of the stored token.
+- New `src/oauth.rs` module (6 unit tests, zero runtime deps
+  beyond the new lightweight `sha2` for PKCE's S256 challenge).
+  Covers the RFC 7636 canonical test vector for the challenge
+  derivation.
+- New `sha2` dependency — only for PKCE S256. Pure-Rust, ~40 KB,
+  no transitive extras.
+
+### Known limitations (follow-ups for 1.x)
+- Client Credentials + Refresh Token flows aren't implemented yet —
+  the Auth tab only offers Authorization Code + PKCE. When the
+  access token expires, click **Get New Token** to re-run the
+  flow manually.
+- Tokens are persisted in `data.json` alongside other auth data,
+  same security model as Bearer. Native-keychain storage remains
+  on the post-1.0 roadmap.
+
+## [0.14.0] — Light theme
 
 ### Added
 - **Light theme** — new `Theme::Light` option in Settings. Flips

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -524,6 +524,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +796,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -846,6 +861,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,6 +904,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cursor-icon"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -891,8 +924,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1923,6 +1967,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -3571,7 +3624,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rusty-requester"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "base64",
  "dirs",
@@ -3587,6 +3640,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2",
  "tokio",
  "uuid",
 ]
@@ -3764,8 +3818,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-requester"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 
 [dependencies]
@@ -18,6 +18,7 @@ serde_yaml = "0.9"
 rfd = "0.15"
 image = { version = "0.25", default-features = false, features = ["png"] }
 egui-phosphor = "0.7"
+sha2 = "0.11.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -17,7 +17,8 @@ Full feature catalog for Rusty Requester. For a quick pitch see the
 - 📝 Tabbed editor: **Params · Headers · Cookies · Body · Auth · Tests**
 - 🔗 **Bidirectional URL ↔ Params sync** (Postman-style): type `?foo=bar` in the URL bar → params populate the table; edit the table → URL bar rebuilds. Auto-growing "ghost" row.
 - 🍪 Cookies list (merged into a `Cookie` header on send)
-- 🔐 Auth presets: **No Auth · Bearer Token · Basic Auth** + **JWT decoder** (Bearer tokens auto-decode below the input — header & payload pretty JSON, scope/exp at a glance)
+- 🔐 Auth presets: **No Auth · Bearer Token · Basic Auth · OAuth 2.0** + **JWT decoder** (Bearer tokens auto-decode below the input — header & payload pretty JSON, scope/exp at a glance)
+- 🪪 **OAuth 2.0 Authorization Code + PKCE** — click **Get New Token** in the Auth tab; browser opens the provider's authorize URL, loopback listener catches the redirect, code is exchanged for a token via the provider's `token_url`. Access token auto-injected as `Authorization: Bearer <token>` on every send. Live status badge (valid / expired / refreshing soon). No client secret required for PKCE clients.
 - 📦 **Body modes**: Raw / `x-www-form-urlencoded` / `multipart/form-data` / **GraphQL** (query + variables, sent as `application/json`)
 - 📐 **Line-numbered request body** with subtle `Beautify` / `Minify` action links
 - 🌱 **Environment variables** — define key/value vars per environment, reference them anywhere with `{{varname}}`. Switch active env from the sidebar.
@@ -230,6 +231,7 @@ Foundations
 - [x] JSON / YAML export & import
 - [x] Bidirectional **URL ↔ Params sync** — type `?k=v` in URL, table populates; edit table, URL rebuilds
 - [x] Bearer / Basic auth presets + **JWT decoder** for Bearer tokens
+- [x] **OAuth 2.0 Authorization Code + PKCE** — in-app browser flow with loopback listener, auto-injects Bearer token on send
 - [x] Body modes: Raw / form-urlencoded / multipart / GraphQL
 - [x] Environment variables — `{{var}}` substitution with active env selector + manage modal
 - [x] Request history — last 200 sends with preview
@@ -279,12 +281,12 @@ Platform
 
 **On the v1.0 pathway:**
 
-- [ ] **OAuth 2.0** flows (Authorization Code + PKCE, Client Credentials, refresh
-      token). Highest-impact remaining feature; tokens slot directly into the env
-      system.
+_Nothing — v0.15.0 ships OAuth 2.0 Auth Code + PKCE, which was the last v1.0 item._
 
 **Post-1.0:**
 
+- [ ] **OAuth 2.0 Client Credentials + Refresh flows** — the first release ships Auth Code + PKCE only.
+- [ ] **Native keychain integration** — back OAuth + Bearer tokens with the OS keychain via the `keyring` crate.
 - [ ] **WebSocket testing** — separate connection lifecycle + per-request message log.
 - [ ] **Pre-request scripts** — Rhai/Boa scripting engine for transformations before send.
 - [ ] **Windows builds** — CI + installer parity with macOS/Linux.

--- a/src/io/curl.rs
+++ b/src/io/curl.rs
@@ -21,6 +21,12 @@ pub fn to_curl(req: &Request) -> String {
         Auth::Bearer { token } if !token.is_empty() => {
             parts.push(format!("-H 'Authorization: Bearer {}'", esc(token)));
         }
+        Auth::OAuth2(s) if !s.access_token.is_empty() => {
+            parts.push(format!(
+                "-H 'Authorization: Bearer {}'",
+                esc(&s.access_token)
+            ));
+        }
         Auth::Basic { username, password } if !username.is_empty() => {
             parts.push(format!("-u '{}:{}'", esc(username), esc(password)));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod io;
 mod macos_menu;
 mod model;
 mod net;
+mod oauth;
 mod snippet;
 mod sse;
 mod theme;
@@ -29,6 +30,14 @@ use model::*;
 struct InFlightRequest {
     handle: tokio::task::JoinHandle<()>,
     rx: std::sync::mpsc::Receiver<net::RequestUpdate>,
+}
+
+/// Result of a successful OAuth2 flow, ready to be copied into the
+/// active request's `Auth::OAuth2` state.
+pub struct OAuth2TokenUpdate {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_at: Option<i64>,
 }
 use snippet::SnippetLang;
 use std::fs;
@@ -148,6 +157,20 @@ struct ApiClient {
     /// banner stays visible across frames. `None` = no update / not
     /// checked yet / current version is latest.
     update_available: Option<String>,
+
+    /// In-flight OAuth 2.0 flow. `Some` while the user is completing
+    /// the authorize-redirect dance in their browser; drained each
+    /// frame. `Ok(tokens)` → copy into the active Auth::OAuth2 state
+    /// and clear; `Err(msg)` → toast the error and clear.
+    oauth_flow_rx: Option<std::sync::mpsc::Receiver<Result<OAuth2TokenUpdate, String>>>,
+    /// Human-readable status line shown under the Auth tab while a
+    /// flow is in progress ("Waiting for browser redirect…", etc.).
+    oauth_flow_status: Option<String>,
+    /// "Get New Token" was clicked this frame — render_auth_tab can't
+    /// call `start_oauth_flow` directly because it's already holding
+    /// a mutable borrow of `editing_auth`. Caller flushes this flag
+    /// after the match ends.
+    oauth_start_requested: bool,
 
     /// Open "save draft" modal state.
     save_draft_open: bool,
@@ -328,6 +351,9 @@ impl Default for ApiClient {
             startup_warning: None,
             update_check_rx: None,
             update_available: None,
+            oauth_flow_rx: None,
+            oauth_flow_status: None,
+            oauth_start_requested: false,
             save_draft_open: false,
             save_draft_tab_idx: None,
             save_draft_target_path: Vec::new(),
@@ -648,6 +674,125 @@ impl ApiClient {
     fn active_environment(&self) -> Option<&Environment> {
         let id = self.state.active_env_id.as_ref()?;
         self.state.environments.iter().find(|e| &e.id == id)
+    }
+
+    /// Kick off an OAuth 2.0 Authorization Code + PKCE flow using the
+    /// config currently showing on the Auth tab. Spawns a background
+    /// thread that opens the browser, waits for the redirect, and
+    /// exchanges the code for a token — result flows back via
+    /// `oauth_flow_rx` and is merged into `editing_auth` on the next
+    /// `update()` frame. Returns immediately; UI shows "Waiting…"
+    /// until the flow completes.
+    fn start_oauth_flow(&mut self) {
+        let Auth::OAuth2(state) = &self.editing_auth else {
+            return;
+        };
+        if state.config.auth_url.trim().is_empty()
+            || state.config.token_url.trim().is_empty()
+            || state.config.client_id.trim().is_empty()
+        {
+            self.show_toast("Fill in Auth URL, Token URL, and Client ID first");
+            return;
+        }
+        let config = state.config.clone();
+        let client = self.http_client.clone();
+        let rt_handle = self.http_runtime.handle().clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.oauth_flow_rx = Some(rx);
+        self.oauth_flow_status = Some("Opening browser…".to_string());
+
+        std::thread::spawn(move || {
+            let flow = match oauth::begin_flow(&config) {
+                Ok(f) => f,
+                Err(e) => {
+                    let _ = tx.send(Err(format!("Flow setup failed: {}", e)));
+                    return;
+                }
+            };
+            let auth_url = flow.authorize_url(&config);
+            if let Err(e) = webbrowser_open(&auth_url) {
+                let _ = tx.send(Err(format!("Could not open browser: {}", e)));
+                return;
+            }
+            // Block up to 2 min for the user to complete the redirect.
+            let code = match flow.wait_for_redirect(std::time::Duration::from_secs(120)) {
+                Ok(c) => c,
+                Err(e) => {
+                    let _ = tx.send(Err(format!("{}", e)));
+                    return;
+                }
+            };
+            let redirect_uri = flow.redirect_uri().to_string();
+            // Run the token exchange on the shared tokio runtime so
+            // we don't build a throwaway runtime per flow.
+            let exchange = rt_handle.block_on(oauth::exchange_code(
+                &client,
+                &config,
+                &code,
+                &flow.verifier,
+                &redirect_uri,
+            ));
+            match exchange {
+                Ok(tr) => {
+                    let expires_at = tr.expires_in_secs.map(|s| {
+                        let now = std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs() as i64)
+                            .unwrap_or(0);
+                        now + s
+                    });
+                    let _ = tx.send(Ok(OAuth2TokenUpdate {
+                        access_token: tr.access_token,
+                        refresh_token: tr.refresh_token,
+                        expires_at,
+                    }));
+                }
+                Err(e) => {
+                    let _ = tx.send(Err(format!("{}", e)));
+                }
+            }
+        });
+    }
+
+    /// Called each `update()` frame — if the OAuth flow has
+    /// completed, drain the result into `editing_auth` (success) or
+    /// a toast (failure). No-op when no flow is in flight.
+    fn poll_oauth_flow(&mut self) {
+        if self.oauth_flow_rx.is_none() {
+            return;
+        }
+        let Some(rx) = &self.oauth_flow_rx else {
+            return;
+        };
+        match rx.try_recv() {
+            Ok(Ok(tokens)) => {
+                if let Auth::OAuth2(ref mut s) = self.editing_auth {
+                    s.access_token = tokens.access_token;
+                    s.refresh_token = tokens.refresh_token;
+                    s.expires_at = tokens.expires_at;
+                }
+                let auth = self.editing_auth.clone();
+                self.update_current_request(|r| r.auth = auth);
+                self.oauth_flow_rx = None;
+                self.oauth_flow_status = None;
+                self.show_toast("OAuth token obtained");
+            }
+            Ok(Err(msg)) => {
+                self.oauth_flow_rx = None;
+                self.oauth_flow_status = None;
+                self.show_toast(format!("OAuth failed: {}", msg));
+            }
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                // Flow still running — bump status if we haven't yet.
+                if self.oauth_flow_status.as_deref() == Some("Opening browser…") {
+                    self.oauth_flow_status = Some("Waiting for browser redirect…".to_string());
+                }
+            }
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                self.oauth_flow_rx = None;
+                self.oauth_flow_status = None;
+            }
+        }
     }
 
     /// Run the current request's extractors against the just-received
@@ -1427,6 +1572,8 @@ impl eframe::App for ApiClient {
         if let Some(msg) = self.startup_warning.take() {
             self.show_toast(msg);
         }
+
+        self.poll_oauth_flow();
 
         // Drain the update-check channel. Only fires once (the tokio
         // task sends at most one message then the sender drops);

--- a/src/model.rs
+++ b/src/model.rs
@@ -202,6 +202,62 @@ pub enum Auth {
         username: String,
         password: String,
     },
+    /// OAuth 2.0 Authorization Code + PKCE flow. Holds the user's
+    /// provider config plus the cached access / refresh tokens from
+    /// the last successful flow. Boxed to keep the `Auth` enum small
+    /// — OAuth config adds ~10 strings worth of payload compared to
+    /// Bearer's single token.
+    #[serde(rename = "OAuth2")]
+    OAuth2(Box<OAuth2State>),
+}
+
+/// Cached OAuth2 state — config (stable) + tokens (refreshed per
+/// flow). Persisted in `data.json` the same way other `Auth` data is.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
+pub struct OAuth2State {
+    pub config: OAuth2Config,
+    /// Access token from the last successful flow. Empty until the
+    /// user clicks "Get New Token" and completes the browser dance.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub access_token: String,
+    /// Refresh token, if the provider returned one. Not used yet by
+    /// the request path (scope: v0.15 ships manual re-auth only);
+    /// persisted so a future auto-refresh can pick it up without a
+    /// schema change.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub refresh_token: String,
+    /// Unix epoch seconds when the access token expires. `None` =
+    /// no expiry info returned (long-lived token, or provider
+    /// omitted `expires_in`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<i64>,
+}
+
+/// User-editable OAuth2 provider config. All fields are free-form
+/// strings so users can point at any RFC 6749-compliant provider.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default)]
+pub struct OAuth2Config {
+    pub auth_url: String,
+    pub token_url: String,
+    pub client_id: String,
+    /// Empty for public clients (the common case for a native app —
+    /// PKCE replaces the secret). Some providers require it anyway
+    /// for "confidential" apps; we send it if non-empty.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub client_secret: String,
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub scope: String,
+    /// Registered redirect URI. Must match what's configured on the
+    /// provider side. We always listen on a random 127.0.0.1 port
+    /// unless the user overrides — the usual setup is to register
+    /// something like `http://127.0.0.1/callback` (many providers
+    /// allow any 127.0.0.1 port for PKCE clients).
+    #[serde(default = "default_redirect_uri")]
+    pub redirect_uri: String,
+}
+
+fn default_redirect_uri() -> String {
+    "http://127.0.0.1/callback".to_string()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -209,6 +265,7 @@ pub enum AuthKind {
     None,
     Bearer,
     Basic,
+    OAuth2,
 }
 
 impl From<&Auth> for AuthKind {
@@ -217,6 +274,7 @@ impl From<&Auth> for AuthKind {
             Auth::None => AuthKind::None,
             Auth::Bearer { .. } => AuthKind::Bearer,
             Auth::Basic { .. } => AuthKind::Basic,
+            Auth::OAuth2(_) => AuthKind::OAuth2,
         }
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -163,6 +163,11 @@ pub async fn execute_request_async(
             username: substitute_vars(username, env),
             password: substitute_vars(password, env),
         },
+        // OAuth2 passes through unchanged — the access token comes
+        // from the stored flow state, not from env-var substitution.
+        // (Users who want env-var tokens should use Bearer auth; OAuth
+        // is for the full authorize-redirect flow.)
+        Auth::OAuth2(s) => Auth::OAuth2(s.clone()),
     };
 
     // Inner block is the former `runtime_handle.block_on(async { … })`
@@ -228,6 +233,15 @@ pub async fn execute_request_async(
         match &sub_auth {
             Auth::Bearer { token } if !token.is_empty() => {
                 req_builder = req_builder.header("Authorization", format!("Bearer {}", token));
+            }
+            Auth::OAuth2(s) if !s.access_token.is_empty() => {
+                // Send the cached access token as a Bearer header.
+                // Expiry is checked by the UI (shows a warning pill
+                // in the Auth tab) so the user can re-run the flow
+                // before the send; this layer trusts the token it's
+                // handed and lets the provider reject it if stale.
+                req_builder =
+                    req_builder.header("Authorization", format!("Bearer {}", s.access_token));
             }
             Auth::Basic { username, password } if !username.is_empty() => {
                 let encoded = base64::engine::general_purpose::STANDARD

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,0 +1,460 @@
+//! OAuth 2.0 Authorization Code + PKCE flow.
+//!
+//! Scope: covers the flow used by most public / SPA / native
+//! clients — no client secret required, PKCE protects the code
+//! exchange. Does NOT implement Client Credentials, Resource Owner
+//! Password, Device Code, or JWT-bearer flows; those can follow
+//! in later 1.x releases without schema breakage.
+//!
+//! End-to-end shape of a flow:
+//!
+//!   1. UI calls `begin_flow(config)` which returns a `FlowHandle`
+//!      holding the PKCE verifier, state parameter, and a local
+//!      `TcpListener` bound to `127.0.0.1:<random>`.
+//!   2. `FlowHandle::authorize_url()` produces the provider URL;
+//!      the caller `open_in_browser`s it.
+//!   3. `FlowHandle::wait_for_redirect(timeout)` blocks until the
+//!      provider redirects the user's browser to our listener.
+//!      Returns the `code` parameter (or an error if state mismatch,
+//!      provider error, timeout).
+//!   4. `exchange_code(config, code, verifier)` POSTs to the
+//!      token endpoint, returning `TokenResponse`.
+//!
+//! Thread safety: the listener blocks the calling thread, so
+//! callers should run the flow on a background thread (`thread::spawn`
+//! is fine — this isn't CPU-bound) and surface the result through
+//! an `mpsc::channel`.
+
+use base64::Engine;
+use sha2::{Digest, Sha256};
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::time::Duration;
+
+use crate::model::OAuth2Config;
+
+#[derive(Debug)]
+pub enum OAuthError {
+    Bind(String),
+    Timeout,
+    StateMismatch,
+    ProviderError(String),
+    Network(String),
+    Parse(String),
+}
+
+impl std::fmt::Display for OAuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Bind(e) => write!(f, "could not bind local callback listener: {}", e),
+            Self::Timeout => write!(f, "timed out waiting for the provider to redirect"),
+            Self::StateMismatch => write!(
+                f,
+                "state parameter mismatch — the redirect was not from our flow"
+            ),
+            Self::ProviderError(m) => write!(f, "provider rejected the request: {}", m),
+            Self::Network(m) => write!(f, "network error: {}", m),
+            Self::Parse(m) => write!(f, "could not parse provider response: {}", m),
+        }
+    }
+}
+
+impl std::error::Error for OAuthError {}
+
+#[derive(Debug, Clone)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_in_secs: Option<i64>,
+}
+
+/// PKCE code verifier (43–128 unreserved chars per RFC 7636). We
+/// use 32 bytes (256 bits) of entropy → 43 base64url chars.
+fn generate_pkce_verifier() -> String {
+    // 32 bytes of entropy by concatenating two UUID v4s. `uuid` is
+    // already a dependency and its v4 uses OS-provided CSPRNG, so
+    // this is cryptographically sound without pulling in `rand` /
+    // `getrandom` as direct deps.
+    let a = uuid::Uuid::new_v4();
+    let b = uuid::Uuid::new_v4();
+    let mut bytes = [0u8; 32];
+    bytes[..16].copy_from_slice(a.as_bytes());
+    bytes[16..].copy_from_slice(b.as_bytes());
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Derive the S256 code challenge from a verifier.
+fn code_challenge_s256(verifier: &str) -> String {
+    let hash = Sha256::digest(verifier.as_bytes());
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hash)
+}
+
+/// Opaque state token — prevents cross-site replay of the redirect.
+fn generate_state() -> String {
+    uuid::Uuid::new_v4().to_string()
+}
+
+pub struct FlowHandle {
+    listener: TcpListener,
+    redirect_uri: String,
+    state: String,
+    pub verifier: String,
+    pub challenge: String,
+}
+
+/// Begin a PKCE flow. Binds a local TCP listener on `127.0.0.1`
+/// (random port) and returns the handle. The caller should
+/// immediately call `authorize_url()` and open it in the user's
+/// browser.
+pub fn begin_flow(config: &OAuth2Config) -> Result<FlowHandle, OAuthError> {
+    let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| OAuthError::Bind(e.to_string()))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| OAuthError::Bind(e.to_string()))?
+        .port();
+    // We override the user's registered redirect_uri port with the
+    // port we just bound — PKCE-capable providers generally allow
+    // any 127.0.0.1 port. Providers that require exact match need
+    // the user to register our exact URI; we provide the default
+    // `http://127.0.0.1/callback` as a placeholder that the user
+    // can refine.
+    let redirect_uri = {
+        let base = config.redirect_uri.trim_end_matches('/');
+        if base.contains("127.0.0.1") || base.contains("localhost") {
+            // Inject the port while preserving any path the user set.
+            rewrite_loopback_port(base, port)
+        } else {
+            base.to_string()
+        }
+    };
+    let verifier = generate_pkce_verifier();
+    let challenge = code_challenge_s256(&verifier);
+    let state = generate_state();
+    Ok(FlowHandle {
+        listener,
+        redirect_uri,
+        state,
+        verifier,
+        challenge,
+    })
+}
+
+/// Replace (or inject) the port on a `http://host[:port][/path]` URL.
+/// Used to pin the callback URL to the port we actually bound.
+fn rewrite_loopback_port(url: &str, port: u16) -> String {
+    let (scheme, rest) = match url.split_once("://") {
+        Some((s, r)) => (s, r),
+        None => ("http", url),
+    };
+    let (host_and_port, path) = match rest.split_once('/') {
+        Some((hp, p)) => (hp, format!("/{}", p)),
+        None => (rest, String::new()),
+    };
+    let host = host_and_port.split(':').next().unwrap_or(host_and_port);
+    format!("{}://{}:{}{}", scheme, host, port, path)
+}
+
+impl FlowHandle {
+    pub fn authorize_url(&self, config: &OAuth2Config) -> String {
+        let mut params: Vec<(&str, String)> = vec![
+            ("response_type", "code".into()),
+            ("client_id", config.client_id.clone()),
+            ("redirect_uri", self.redirect_uri.clone()),
+            ("state", self.state.clone()),
+            ("code_challenge", self.challenge.clone()),
+            ("code_challenge_method", "S256".into()),
+        ];
+        if !config.scope.trim().is_empty() {
+            params.push(("scope", config.scope.clone()));
+        }
+        let query: String = params
+            .iter()
+            .map(|(k, v)| format!("{}={}", url_encode(k), url_encode(v)))
+            .collect::<Vec<_>>()
+            .join("&");
+        let sep = if config.auth_url.contains('?') {
+            '&'
+        } else {
+            '?'
+        };
+        format!("{}{}{}", config.auth_url.trim_end_matches('&'), sep, query)
+    }
+
+    pub fn redirect_uri(&self) -> &str {
+        &self.redirect_uri
+    }
+
+    /// Block until the user's browser hits our callback listener, or
+    /// the timeout elapses. Returns the authorization `code` value.
+    pub fn wait_for_redirect(&self, timeout: Duration) -> Result<String, OAuthError> {
+        self.listener
+            .set_nonblocking(false)
+            .map_err(|e| OAuthError::Bind(e.to_string()))?;
+        // Per-accept read timeout so an unresponsive browser doesn't
+        // wedge the listener forever. Loop until we see a GET on
+        // the callback path or exceed `timeout`.
+        let deadline = std::time::Instant::now() + timeout;
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            if remaining.is_zero() {
+                return Err(OAuthError::Timeout);
+            }
+            self.listener
+                .set_nonblocking(true)
+                .map_err(|e| OAuthError::Bind(e.to_string()))?;
+            match self.listener.accept() {
+                Ok((mut stream, _addr)) => {
+                    stream
+                        .set_read_timeout(Some(Duration::from_secs(3)))
+                        .map_err(|e| OAuthError::Network(e.to_string()))?;
+                    let mut buf = [0u8; 4096];
+                    let n = stream
+                        .read(&mut buf)
+                        .map_err(|e| OAuthError::Network(e.to_string()))?;
+                    let req = String::from_utf8_lossy(&buf[..n]);
+                    // Reply with a browser-friendly page telling the
+                    // user they can close the window. Must write
+                    // before we drop `stream`, otherwise the browser
+                    // shows "connection reset".
+                    let body = b"<!doctype html><html><body style='font-family:system-ui;padding:40px;text-align:center'><h2>\xE2\x9C\x93 Authentication complete</h2><p>You can close this window and return to Rusty Requester.</p></body></html>";
+                    let resp = format!(
+                        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        body.len()
+                    );
+                    let _ = stream.write_all(resp.as_bytes());
+                    let _ = stream.write_all(body);
+                    let _ = stream.flush();
+                    return self.parse_callback_query(&req);
+                }
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(200));
+                    continue;
+                }
+                Err(e) => return Err(OAuthError::Network(e.to_string())),
+            }
+        }
+    }
+
+    fn parse_callback_query(&self, request: &str) -> Result<String, OAuthError> {
+        // Request line: `GET /callback?code=...&state=... HTTP/1.1`
+        let first_line = request.lines().next().unwrap_or("");
+        let path = first_line.split_whitespace().nth(1).unwrap_or("");
+        let query = path.split_once('?').map(|(_, q)| q).unwrap_or("");
+        let mut code: Option<String> = None;
+        let mut state: Option<String> = None;
+        let mut error: Option<String> = None;
+        let mut error_desc: Option<String> = None;
+        for pair in query.split('&') {
+            let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+            let v = url_decode(v);
+            match k {
+                "code" => code = Some(v),
+                "state" => state = Some(v),
+                "error" => error = Some(v),
+                "error_description" => error_desc = Some(v),
+                _ => {}
+            }
+        }
+        if let Some(e) = error {
+            let msg = error_desc
+                .map(|d| format!("{}: {}", e, d))
+                .unwrap_or_else(|| e);
+            return Err(OAuthError::ProviderError(msg));
+        }
+        if state.as_deref() != Some(self.state.as_str()) {
+            return Err(OAuthError::StateMismatch);
+        }
+        code.ok_or_else(|| OAuthError::Parse("missing `code` parameter".into()))
+    }
+}
+
+/// Exchange an authorization code for an access token.
+pub async fn exchange_code(
+    client: &reqwest::Client,
+    config: &OAuth2Config,
+    code: &str,
+    verifier: &str,
+    redirect_uri: &str,
+) -> Result<TokenResponse, OAuthError> {
+    let mut form: Vec<(&str, &str)> = vec![
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("redirect_uri", redirect_uri),
+        ("client_id", config.client_id.as_str()),
+        ("code_verifier", verifier),
+    ];
+    if !config.client_secret.is_empty() {
+        form.push(("client_secret", config.client_secret.as_str()));
+    }
+    let resp = client
+        .post(&config.token_url)
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| OAuthError::Network(e.to_string()))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(OAuthError::ProviderError(format!(
+            "token endpoint returned {}: {}",
+            status, body
+        )));
+    }
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| OAuthError::Parse(e.to_string()))?;
+    parse_token_response(&json)
+}
+
+fn parse_token_response(json: &serde_json::Value) -> Result<TokenResponse, OAuthError> {
+    let access_token = json
+        .get("access_token")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| OAuthError::Parse("missing `access_token` in response".into()))?
+        .to_string();
+    let refresh_token = json
+        .get("refresh_token")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let expires_in_secs = json.get("expires_in").and_then(|v| v.as_i64());
+    Ok(TokenResponse {
+        access_token,
+        refresh_token,
+        expires_in_secs,
+    })
+}
+
+fn url_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
+}
+
+fn url_decode(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'+' => {
+                out.push(b' ');
+                i += 1;
+            }
+            b'%' if i + 2 < bytes.len() => {
+                let hex = std::str::from_utf8(&bytes[i + 1..i + 3]).unwrap_or("");
+                match u8::from_str_radix(hex, 16) {
+                    Ok(b) => {
+                        out.push(b);
+                        i += 3;
+                    }
+                    Err(_) => {
+                        out.push(bytes[i]);
+                        i += 1;
+                    }
+                }
+            }
+            b => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkce_verifier_length_in_range() {
+        let v = generate_pkce_verifier();
+        // 32 bytes → 43 base64url chars (no padding).
+        assert_eq!(v.len(), 43);
+        // Only unreserved chars per RFC 7636.
+        assert!(v
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+    }
+
+    #[test]
+    fn s256_challenge_is_deterministic() {
+        // Canonical RFC 7636 Appendix B vector:
+        //   verifier  = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+        //   challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        let v = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        let c = code_challenge_s256(v);
+        assert_eq!(c, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM");
+    }
+
+    #[test]
+    fn authorize_url_encodes_params() {
+        let cfg = OAuth2Config {
+            auth_url: "https://example.com/authorize".into(),
+            token_url: "https://example.com/token".into(),
+            client_id: "abc 123".into(),
+            client_secret: String::new(),
+            scope: "read write".into(),
+            redirect_uri: "http://127.0.0.1/callback".into(),
+        };
+        let fh = FlowHandle {
+            listener: TcpListener::bind("127.0.0.1:0").unwrap(),
+            redirect_uri: "http://127.0.0.1:54321/callback".into(),
+            state: "s".into(),
+            verifier: "v".into(),
+            challenge: "ch".into(),
+        };
+        let u = fh.authorize_url(&cfg);
+        assert!(u.starts_with("https://example.com/authorize?"));
+        assert!(u.contains("response_type=code"));
+        assert!(u.contains("client_id=abc%20123"));
+        assert!(u.contains("scope=read%20write"));
+        assert!(u.contains("code_challenge=ch"));
+        assert!(u.contains("code_challenge_method=S256"));
+        assert!(u.contains("redirect_uri=http%3A%2F%2F127.0.0.1%3A54321%2Fcallback"));
+    }
+
+    #[test]
+    fn rewrite_loopback_port_preserves_path() {
+        let out = rewrite_loopback_port("http://127.0.0.1/callback", 54321);
+        assert_eq!(out, "http://127.0.0.1:54321/callback");
+        let out2 = rewrite_loopback_port("http://localhost:8080/cb", 54321);
+        assert_eq!(out2, "http://localhost:54321/cb");
+        let out3 = rewrite_loopback_port("http://127.0.0.1", 54321);
+        assert_eq!(out3, "http://127.0.0.1:54321");
+    }
+
+    #[test]
+    fn parses_token_response() {
+        let json = serde_json::json!({
+            "access_token": "at",
+            "refresh_token": "rt",
+            "expires_in": 3600,
+            "token_type": "Bearer"
+        });
+        let t = parse_token_response(&json).unwrap();
+        assert_eq!(t.access_token, "at");
+        assert_eq!(t.refresh_token, "rt");
+        assert_eq!(t.expires_in_secs, Some(3600));
+    }
+
+    #[test]
+    fn parses_token_response_missing_refresh() {
+        let json = serde_json::json!({
+            "access_token": "at",
+            "expires_in": 3600
+        });
+        let t = parse_token_response(&json).unwrap();
+        assert_eq!(t.access_token, "at");
+        assert_eq!(t.refresh_token, "");
+    }
+}

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -415,6 +415,12 @@ fn collect_send_headers(req: &Request) -> Vec<(String, String)> {
             out.push(("Authorization".into(), format!("Bearer {}", token)));
         }
     }
+    // OAuth2 → Bearer <access_token>, mirroring the send path.
+    if let Auth::OAuth2(s) = &req.auth {
+        if !s.access_token.is_empty() {
+            out.push(("Authorization".into(), format!("Bearer {}", s.access_token)));
+        }
+    }
     out
 }
 

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -468,10 +468,11 @@ impl ApiClient {
         } else {
             "Body •".to_string()
         };
-        let auth_label = match self.editing_auth {
+        let auth_label = match &self.editing_auth {
             Auth::None => "Auth".to_string(),
             Auth::Bearer { .. } => "Auth (Bearer)".to_string(),
             Auth::Basic { .. } => "Auth (Basic)".to_string(),
+            Auth::OAuth2(_) => "Auth (OAuth 2.0)".to_string(),
         };
         let active_extractors = self
             .editing_extractors
@@ -814,11 +815,13 @@ impl ApiClient {
                     AuthKind::None => "No Auth",
                     AuthKind::Bearer => "Bearer Token",
                     AuthKind::Basic => "Basic Auth",
+                    AuthKind::OAuth2 => "OAuth 2.0",
                 })
                 .show_ui(ui, |ui| {
                     ui.selectable_value(&mut kind, AuthKind::None, "No Auth");
                     ui.selectable_value(&mut kind, AuthKind::Bearer, "Bearer Token");
                     ui.selectable_value(&mut kind, AuthKind::Basic, "Basic Auth");
+                    ui.selectable_value(&mut kind, AuthKind::OAuth2, "OAuth 2.0");
                 });
         });
 
@@ -841,6 +844,10 @@ impl ApiClient {
                         username: String::new(),
                         password: String::new(),
                     },
+                },
+                AuthKind::OAuth2 => match &self.editing_auth {
+                    Auth::OAuth2(s) => Auth::OAuth2(s.clone()),
+                    _ => Auth::OAuth2(Box::default()),
                 },
             };
             let auth = self.editing_auth.clone();
@@ -946,10 +953,163 @@ impl ApiClient {
                     }
                 });
             }
+            Auth::OAuth2(s) => {
+                // Config form — six fields. Stored persistently on
+                // the request; `Get New Token` uses these to drive
+                // the PKCE flow.
+                fn field(
+                    ui: &mut egui::Ui,
+                    label: &str,
+                    value: &mut String,
+                    hint: &str,
+                    password: bool,
+                ) -> bool {
+                    ui.horizontal(|ui| {
+                        ui.label(egui::RichText::new(label).color(C_ACCENT));
+                        let mut edit = egui::TextEdit::singleline(value)
+                            .desired_width(ui.available_width() - 140.0)
+                            .hint_text(hint);
+                        if password {
+                            edit = edit.password(true);
+                        }
+                        ui.add(edit).changed()
+                    })
+                    .inner
+                }
+                changed |= field(
+                    ui,
+                    "Auth URL",
+                    &mut s.config.auth_url,
+                    "https://provider.example.com/oauth/authorize",
+                    false,
+                );
+                changed |= field(
+                    ui,
+                    "Token URL",
+                    &mut s.config.token_url,
+                    "https://provider.example.com/oauth/token",
+                    false,
+                );
+                changed |= field(ui, "Client ID", &mut s.config.client_id, "", false);
+                changed |= field(
+                    ui,
+                    "Client secret",
+                    &mut s.config.client_secret,
+                    "(public / PKCE clients: leave empty)",
+                    true,
+                );
+                changed |= field(
+                    ui,
+                    "Scope",
+                    &mut s.config.scope,
+                    "read:all write:all",
+                    false,
+                );
+                changed |= field(
+                    ui,
+                    "Redirect URI",
+                    &mut s.config.redirect_uri,
+                    "http://127.0.0.1/callback",
+                    false,
+                );
+
+                ui.add_space(8.0);
+                // Status line + action button.
+                let now = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0);
+                let (status_text, status_color) = if s.access_token.is_empty() {
+                    ("No token yet — click Get New Token", C_MUTED)
+                } else if let Some(exp) = s.expires_at {
+                    if exp <= now {
+                        ("Access token expired — click Get New Token", C_RED)
+                    } else {
+                        let secs = exp - now;
+                        let min = secs / 60;
+                        if min > 60 {
+                            ("Access token valid", C_GREEN)
+                        } else if min > 1 {
+                            ("Access token valid (refreshing soon)", C_ORANGE)
+                        } else {
+                            ("Access token valid (<1 min left)", C_ORANGE)
+                        }
+                    }
+                } else {
+                    ("Access token stored (no expiry info)", C_GREEN)
+                };
+                // Collect intents from the closures (can't call
+                // `self.start_oauth_flow()` while `s` holds a mutable
+                // borrow of `self.editing_auth`).
+                let busy = self.oauth_flow_rx.is_some();
+                let flow_status = self.oauth_flow_status.clone();
+                let has_token = !s.access_token.is_empty();
+                let mut start_flow = false;
+                let mut clear_token = false;
+                ui.horizontal(|ui| {
+                    ui.label(
+                        egui::RichText::new(status_text)
+                            .color(status_color)
+                            .size(12.0),
+                    );
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let btn_text = if busy { "Waiting…" } else { "Get New Token" };
+                        let btn = egui::Button::new(
+                            egui::RichText::new(btn_text)
+                                .color(egui::Color32::WHITE)
+                                .strong(),
+                        )
+                        .fill(C_ACCENT)
+                        .min_size(egui::vec2(140.0, 28.0));
+                        let resp = ui.add_enabled(!busy, btn);
+                        if resp.clicked() {
+                            start_flow = true;
+                        }
+                        if has_token && ui.small_button("Clear token").clicked() {
+                            clear_token = true;
+                        }
+                    });
+                });
+                if clear_token {
+                    s.access_token.clear();
+                    s.refresh_token.clear();
+                    s.expires_at = None;
+                    changed = true;
+                }
+                if let Some(msg) = flow_status {
+                    ui.add_space(4.0);
+                    ui.label(egui::RichText::new(msg).color(C_MUTED).size(11.0));
+                }
+                // `start_flow` is handled after the match ends (below)
+                // so we don't hold `&mut self.editing_auth` across the
+                // call to `self.start_oauth_flow()`.
+                if start_flow {
+                    self.oauth_start_requested = true;
+                }
+
+                if !s.access_token.is_empty() {
+                    ui.add_space(6.0);
+                    ui.label(
+                        egui::RichText::new("Access token (stored in data.json)")
+                            .size(10.5)
+                            .color(C_MUTED),
+                    );
+                    // Masked preview — show first + last 8 chars.
+                    let preview = mask_token(&s.access_token);
+                    ui.label(
+                        egui::RichText::new(preview)
+                            .font(egui::FontId::monospace(11.5))
+                            .color(C_TEXT),
+                    );
+                }
+            }
         }
         if changed {
             let auth = self.editing_auth.clone();
             self.update_current_request(|r| r.auth = auth);
+        }
+        if std::mem::take(&mut self.oauth_start_requested) {
+            self.start_oauth_flow();
         }
     }
 

--- a/src/widgets.rs
+++ b/src/widgets.rs
@@ -1128,3 +1128,17 @@ pub fn sanitize_filename(name: &str) -> Option<String> {
         Some(trimmed)
     }
 }
+
+/// Mask a secret token for display — shows first 8 and last 8 chars,
+/// with a "···" separator. Strings under 20 chars render as a
+/// row of asterisks so nothing leaks.
+pub fn mask_token(token: &str) -> String {
+    let n = token.chars().count();
+    if n <= 20 {
+        return "*".repeat(n.min(16));
+    }
+    let start: String = token.chars().take(8).collect();
+    let end: String = token.chars().rev().take(8).collect();
+    let end: String = end.chars().rev().collect();
+    format!("{} ··· {}", start, end)
+}


### PR DESCRIPTION
- **Release v0.14.0**
- **Add OAuth 2.0 Authorization Code + PKCE flow**
- **Inject OAuth2 access token as Bearer on send and in exports**
- **Add OAuth 2.0 config form and flow trigger to Auth tab**
- **Document OAuth 2.0 support and refresh v1.0 roadmap**
