### PR TITLE
Add saved Collection Runner presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## [Unreleased]
+
+### Added
+- **Saved Collection Runner presets.** Runner configurations can now be
+  saved, loaded, renamed, duplicated, and deleted, including all-collection
+  or folder scope, active environment selection, and explicit data-row text.
+  Missing folder or environment references fall back gracefully when loaded.
+
 ## [0.23.0] — 2026-06-17
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,9 @@ struct ApiClient {
     confirm_restore_backup_path: Option<PathBuf>,
     runner_scope_folder_id: Option<String>,
     runner_data_rows: String,
+    runner_selected_preset_id: Option<String>,
+    runner_preset_name_input: String,
+    runner_preset_rename_input: String,
     runner_results: Vec<RunnerResultRow>,
     runner_status: String,
     runner_in_flight: Option<InFlightCollectionRun>,
@@ -404,7 +407,7 @@ impl Default for ApiClient {
         // backup by `load_state`; we surface the path via
         // `startup_warning` so the user sees a toast on first frame.
         let (state, startup_warning) = match Self::load_state(&storage_path) {
-            LoadOutcome::Ok(s) => (s, None),
+            LoadOutcome::Ok(s) => (*s, None),
             LoadOutcome::Fresh => (Self::fresh_state(), None),
             LoadOutcome::Corrupted { backup_path, error } => {
                 eprintln!(
@@ -473,6 +476,9 @@ impl Default for ApiClient {
             confirm_restore_backup_path: None,
             runner_scope_folder_id: None,
             runner_data_rows: String::new(),
+            runner_selected_preset_id: None,
+            runner_preset_name_input: String::new(),
+            runner_preset_rename_input: String::new(),
             runner_results: Vec::new(),
             runner_status: String::new(),
             runner_in_flight: None,
@@ -585,7 +591,7 @@ fn restored_active_tab(open_tabs: &[OpenTab], active_tab_id: Option<&str>) -> Op
 /// caller should surface the backup path so the user knows where
 /// their old data went.
 enum LoadOutcome {
-    Ok(AppState),
+    Ok(Box<AppState>),
     Fresh,
     Corrupted { backup_path: PathBuf, error: String },
 }
@@ -610,6 +616,7 @@ impl ApiClient {
             open_tabs: vec![],
             active_tab_id: None,
             settings: AppSettings::default(),
+            runner_presets: vec![],
         }
     }
 
@@ -620,7 +627,7 @@ impl ApiClient {
             Err(_) => return LoadOutcome::Fresh, // treat other IO errors as fresh; worst case is an empty workspace
         };
         match serde_json::from_str::<AppState>(&data) {
-            Ok(state) => LoadOutcome::Ok(state),
+            Ok(state) => LoadOutcome::Ok(Box::new(state)),
             Err(e) => {
                 // Move the broken file aside so we never silently clobber
                 // the user's data on the next save. Timestamped so
@@ -1905,7 +1912,7 @@ impl ApiClient {
         match backup::restore_backup(&self.storage_path, backup_path) {
             Ok(_) => match Self::load_state(&self.storage_path) {
                 LoadOutcome::Ok(state) => {
-                    self.state = state;
+                    self.state = *state;
                     if let Some(tab) = restored_active_tab(
                         &self.state.open_tabs,
                         self.state.active_tab_id.as_deref(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -411,6 +411,41 @@ pub struct AppState {
     /// Exposed via the Settings modal in the sidebar.
     #[serde(default)]
     pub settings: AppSettings,
+    /// Named Collection Runner configurations. Presets intentionally store
+    /// only runner scope, active environment selection, and optional data-row
+    /// text; they do not copy environment variables or secrets.
+    #[serde(default)]
+    pub runner_presets: Vec<RunnerPreset>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct RunnerPreset {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub scope: RunnerPresetScope,
+    /// Active environment id to select when loading the preset. This is only a
+    /// reference; environment variables and cookies are never copied here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub env_id: Option<String>,
+    /// Display fallback for missing/deleted environments.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub env_name: String,
+    /// Optional CSV/JSON runner data rows. These values are visible in the
+    /// preset UI before saving because they may contain sensitive values.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub data_rows: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub enum RunnerPresetScope {
+    #[default]
+    All,
+    Folder {
+        folder_id: String,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        folder_name: String,
+    },
 }
 
 /// User-configurable networking / safety knobs. Defaults are tuned so
@@ -644,4 +679,45 @@ pub struct ResponseData {
     pub waiting_ms: u64,
     pub download_ms: u64,
     pub total_ms: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_state_loads_without_runner_presets() {
+        let state: AppState = serde_json::from_str(r#"{"folders":[]}"#).unwrap();
+        assert!(state.runner_presets.is_empty());
+    }
+
+    #[test]
+    fn runner_preset_defaults_to_all_scope() {
+        let preset: RunnerPreset =
+            serde_json::from_str(r#"{"id":"preset-1","name":"Smoke"}"#).unwrap();
+
+        assert_eq!(preset.scope, RunnerPresetScope::All);
+        assert_eq!(preset.env_id, None);
+        assert!(preset.env_name.is_empty());
+        assert!(preset.data_rows.is_empty());
+    }
+
+    #[test]
+    fn runner_preset_stores_env_selection_not_env_values() {
+        let preset = RunnerPreset {
+            id: "preset-1".to_string(),
+            name: "Prod smoke".to_string(),
+            scope: RunnerPresetScope::All,
+            env_id: Some("env-prod".to_string()),
+            env_name: "Production".to_string(),
+            data_rows: String::new(),
+        };
+
+        let json = serde_json::to_string(&preset).unwrap();
+
+        assert!(json.contains("env-prod"));
+        assert!(json.contains("Production"));
+        assert!(!json.contains("variables"));
+        assert!(!json.contains("cookies"));
+    }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -1074,7 +1074,7 @@ impl ApiClient {
         }
 
         if let Some(scope_id) = self.runner_scope_folder_id.as_deref() {
-            if runner::collect_requests(&self.state.folders, Some(scope_id)).is_empty() {
+            if crate::find_folder_by_id(&self.state.folders, scope_id).is_none() {
                 self.runner_scope_folder_id = None;
             }
         }
@@ -1082,11 +1082,39 @@ impl ApiClient {
             count_runner_requests(&self.state.folders, self.runner_scope_folder_id.as_deref());
         let scope_options = runner_scope_options(&self.state.folders);
         let data_rows_label = runner_data_rows_label(&self.runner_data_rows);
+        let preset_options: Vec<(String, String)> = self
+            .state
+            .runner_presets
+            .iter()
+            .map(|p| (p.id.clone(), p.name.clone()))
+            .collect();
+        if self
+            .runner_selected_preset_id
+            .as_ref()
+            .is_some_and(|id| !preset_options.iter().any(|(preset_id, _)| preset_id == id))
+        {
+            self.runner_selected_preset_id = None;
+            self.runner_preset_rename_input.clear();
+        }
+        let selected_preset = self
+            .runner_selected_preset_id
+            .as_ref()
+            .and_then(|id| self.state.runner_presets.iter().find(|p| &p.id == id))
+            .cloned();
+        let selected_preset_label = selected_preset
+            .as_ref()
+            .map(|p| p.name.clone())
+            .unwrap_or_else(|| "Choose preset".to_string());
         let mut open = self.show_runner_modal;
         let mut run_requested = false;
         let mut cancel_requested = false;
         let mut export_csv_requested = false;
         let mut export_html_requested = false;
+        let mut save_preset_requested = false;
+        let mut load_preset_id: Option<String> = None;
+        let mut rename_preset_id: Option<String> = None;
+        let mut duplicate_preset_id: Option<String> = None;
+        let mut delete_preset_id: Option<String> = None;
         let runner_busy = self.runner_in_flight.is_some();
 
         egui::Window::new("Collection Runner")
@@ -1167,6 +1195,123 @@ impl ApiClient {
                                     .size(11.0)
                                     .color(muted()),
                                 );
+                            });
+
+                        ui.add_space(12.0);
+                        ui.label(
+                            egui::RichText::new("Presets")
+                                .size(11.0)
+                                .strong()
+                                .color(muted()),
+                        );
+                        ui.add_space(4.0);
+                        egui::Frame::none()
+                            .fill(elevated())
+                            .stroke(egui::Stroke::new(1.0, border()))
+                            .rounding(6.0)
+                            .inner_margin(egui::Margin::same(10.0))
+                            .show(ui, |ui| {
+                                ui.label(
+                                    egui::RichText::new(
+                                        "Presets save scope, active environment selection, and data rows as shown. Data row values may include secrets.",
+                                    )
+                                    .size(11.0)
+                                    .color(muted()),
+                                );
+                                ui.add_space(6.0);
+                                ui.horizontal(|ui| {
+                                    ui.add(
+                                        egui::TextEdit::singleline(
+                                            &mut self.runner_preset_name_input,
+                                        )
+                                        .desired_width(130.0)
+                                        .hint_text(hint("Preset name")),
+                                    );
+                                    if ui
+                                        .add_enabled(
+                                            !runner_busy,
+                                            egui::Button::new("Save current"),
+                                        )
+                                        .on_hover_text(
+                                            "Saves the current scope, active environment id, and visible data rows",
+                                        )
+                                        .clicked()
+                                    {
+                                        save_preset_requested = true;
+                                    }
+                                });
+
+                                ui.add_space(6.0);
+                                egui::ComboBox::from_id_salt("runner_preset_picker")
+                                    .selected_text(selected_preset_label)
+                                    .width(ui.available_width())
+                                    .show_ui(ui, |ui| {
+                                        for (id, name) in &preset_options {
+                                            let selected =
+                                                self.runner_selected_preset_id.as_deref()
+                                                    == Some(id.as_str());
+                                            if ui.selectable_label(selected, name).clicked() {
+                                                self.runner_selected_preset_id = Some(id.clone());
+                                                self.runner_preset_rename_input = name.clone();
+                                            }
+                                        }
+                                    });
+
+                                if let Some(preset) = &selected_preset {
+                                    if self.runner_preset_rename_input.is_empty() {
+                                        self.runner_preset_rename_input = preset.name.clone();
+                                    }
+                                    ui.add_space(6.0);
+                                    ui.horizontal(|ui| {
+                                        if ui
+                                            .add_enabled(!runner_busy, egui::Button::new("Load"))
+                                            .clicked()
+                                        {
+                                            load_preset_id = Some(preset.id.clone());
+                                        }
+                                        if ui
+                                            .add_enabled(!runner_busy, egui::Button::new("Duplicate"))
+                                            .clicked()
+                                        {
+                                            duplicate_preset_id = Some(preset.id.clone());
+                                        }
+                                        if ui
+                                            .add_enabled(!runner_busy, egui::Button::new("Delete"))
+                                            .clicked()
+                                        {
+                                            delete_preset_id = Some(preset.id.clone());
+                                        }
+                                    });
+                                    ui.add_space(4.0);
+                                    ui.horizontal(|ui| {
+                                        ui.add(
+                                            egui::TextEdit::singleline(
+                                                &mut self.runner_preset_rename_input,
+                                            )
+                                            .desired_width(130.0)
+                                            .hint_text(hint("Rename preset")),
+                                        );
+                                        if ui
+                                            .add_enabled(!runner_busy, egui::Button::new("Rename"))
+                                            .clicked()
+                                        {
+                                            rename_preset_id = Some(preset.id.clone());
+                                        }
+                                    });
+                                    ui.add_space(4.0);
+                                    ui.label(
+                                        egui::RichText::new(runner_preset_summary(preset))
+                                            .size(11.0)
+                                            .color(muted()),
+                                    );
+                                } else if preset_options.is_empty() {
+                                    ui.add_space(4.0);
+                                    ui.label(
+                                        egui::RichText::new("No presets saved")
+                                            .size(11.0)
+                                            .color(muted()),
+                                    );
+                                }
                             });
 
                         ui.add_space(12.0);
@@ -1334,6 +1479,21 @@ impl ApiClient {
 
         self.show_runner_modal = open;
 
+        if save_preset_requested {
+            self.save_current_runner_preset();
+        }
+        if let Some(id) = load_preset_id {
+            self.load_runner_preset(&id);
+        }
+        if let Some(id) = rename_preset_id {
+            self.rename_runner_preset(&id);
+        }
+        if let Some(id) = duplicate_preset_id {
+            self.duplicate_runner_preset(&id);
+        }
+        if let Some(id) = delete_preset_id {
+            self.delete_runner_preset(&id);
+        }
         if run_requested {
             self.start_collection_runner();
         }
@@ -1348,6 +1508,166 @@ impl ApiClient {
         }
         if export_html_requested {
             self.export_runner_report("html");
+        }
+    }
+
+    fn save_current_runner_preset(&mut self) {
+        let name = trimmed_or_default(
+            &self.runner_preset_name_input,
+            format!("Runner Preset {}", self.state.runner_presets.len() + 1),
+        );
+        let preset = self.current_runner_preset(name);
+        self.runner_selected_preset_id = Some(preset.id.clone());
+        self.runner_preset_rename_input = preset.name.clone();
+        self.runner_preset_name_input.clear();
+        self.state.runner_presets.push(preset);
+        self.save_state();
+        self.show_toast("Runner preset saved");
+    }
+
+    fn load_runner_preset(&mut self, preset_id: &str) {
+        let Some(preset) = self
+            .state
+            .runner_presets
+            .iter()
+            .find(|p| p.id == preset_id)
+            .cloned()
+        else {
+            return;
+        };
+
+        let mut notes = Vec::new();
+        match &preset.scope {
+            RunnerPresetScope::All => {
+                self.runner_scope_folder_id = None;
+            }
+            RunnerPresetScope::Folder {
+                folder_id,
+                folder_name,
+            } => {
+                if crate::find_folder_by_id(&self.state.folders, folder_id).is_some() {
+                    self.runner_scope_folder_id = Some(folder_id.clone());
+                } else {
+                    self.runner_scope_folder_id = None;
+                    let label = if folder_name.is_empty() {
+                        "saved folder".to_string()
+                    } else {
+                        format!("'{}'", folder_name)
+                    };
+                    notes.push(format!(
+                        "folder scope {} was not found; using all collections",
+                        label
+                    ));
+                }
+            }
+        }
+
+        if let Some(env_id) = &preset.env_id {
+            if self.state.environments.iter().any(|env| &env.id == env_id) {
+                self.state.active_env_id = Some(env_id.clone());
+            } else {
+                self.state.active_env_id = None;
+                let label = if preset.env_name.is_empty() {
+                    "saved environment".to_string()
+                } else {
+                    format!("'{}'", preset.env_name)
+                };
+                notes.push(format!(
+                    "environment {} was not found; using no environment",
+                    label
+                ));
+            }
+        } else {
+            self.state.active_env_id = None;
+        }
+
+        self.runner_data_rows = preset.data_rows.clone();
+        self.runner_selected_preset_id = Some(preset.id.clone());
+        self.runner_preset_rename_input = preset.name.clone();
+        self.runner_status = if notes.is_empty() {
+            format!("Loaded runner preset '{}'.", preset.name)
+        } else {
+            format!(
+                "Loaded runner preset '{}': {}.",
+                preset.name,
+                notes.join("; ")
+            )
+        };
+        self.save_state();
+    }
+
+    fn rename_runner_preset(&mut self, preset_id: &str) {
+        let name = self.runner_preset_rename_input.trim();
+        if name.is_empty() {
+            self.runner_status = "Preset name cannot be empty.".to_string();
+            return;
+        }
+        let Some(preset) = self
+            .state
+            .runner_presets
+            .iter_mut()
+            .find(|p| p.id == preset_id)
+        else {
+            return;
+        };
+        preset.name = name.to_string();
+        self.save_state();
+        self.show_toast("Runner preset renamed");
+    }
+
+    fn duplicate_runner_preset(&mut self, preset_id: &str) {
+        let Some(mut preset) = self
+            .state
+            .runner_presets
+            .iter()
+            .find(|p| p.id == preset_id)
+            .cloned()
+        else {
+            return;
+        };
+        preset.id = Uuid::new_v4().to_string();
+        preset.name = unique_runner_preset_name(&self.state.runner_presets, &preset.name);
+        self.runner_selected_preset_id = Some(preset.id.clone());
+        self.runner_preset_rename_input = preset.name.clone();
+        self.state.runner_presets.push(preset);
+        self.save_state();
+        self.show_toast("Runner preset duplicated");
+    }
+
+    fn delete_runner_preset(&mut self, preset_id: &str) {
+        let before = self.state.runner_presets.len();
+        self.state
+            .runner_presets
+            .retain(|preset| preset.id != preset_id);
+        if self.state.runner_presets.len() == before {
+            return;
+        }
+        if self.runner_selected_preset_id.as_deref() == Some(preset_id) {
+            self.runner_selected_preset_id = None;
+            self.runner_preset_rename_input.clear();
+        }
+        self.save_state();
+        self.show_toast("Runner preset deleted");
+    }
+
+    fn current_runner_preset(&self, name: String) -> RunnerPreset {
+        let scope = match &self.runner_scope_folder_id {
+            Some(folder_id) => RunnerPresetScope::Folder {
+                folder_id: folder_id.clone(),
+                folder_name: crate::find_folder_by_id(&self.state.folders, folder_id)
+                    .map(|folder| folder.name.clone())
+                    .unwrap_or_default(),
+            },
+            None => RunnerPresetScope::All,
+        };
+        let env = self.active_environment();
+        RunnerPreset {
+            id: Uuid::new_v4().to_string(),
+            name,
+            scope,
+            env_id: env.map(|env| env.id.clone()),
+            env_name: env.map(|env| env.name.clone()).unwrap_or_default(),
+            data_rows: self.runner_data_rows.clone(),
         }
     }
 
@@ -3001,6 +3321,60 @@ fn runner_data_rows_label(data_rows: &str) -> String {
     } else {
         format!("{} data row{}", count, if count == 1 { "" } else { "s" })
     }
+}
+
+fn runner_preset_summary(preset: &RunnerPreset) -> String {
+    let scope = match &preset.scope {
+        RunnerPresetScope::All => "all collections".to_string(),
+        RunnerPresetScope::Folder {
+            folder_name,
+            folder_id,
+        } => {
+            if folder_name.is_empty() {
+                format!("folder {}", folder_id)
+            } else {
+                format!("folder '{}'", folder_name)
+            }
+        }
+    };
+    let env = preset
+        .env_id
+        .as_ref()
+        .map(|_| {
+            if preset.env_name.is_empty() {
+                "saved environment".to_string()
+            } else {
+                format!("environment '{}'", preset.env_name)
+            }
+        })
+        .unwrap_or_else(|| "no environment".to_string());
+    let rows = runner_data_rows_label(&preset.data_rows);
+    format!("Loads {}, {}, {}", scope, env, rows.to_ascii_lowercase())
+}
+
+fn trimmed_or_default(value: &str, default: String) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        default
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn unique_runner_preset_name(presets: &[RunnerPreset], base: &str) -> String {
+    let base = base.trim();
+    let base = if base.is_empty() {
+        "Runner Preset"
+    } else {
+        base
+    };
+    let mut candidate = format!("{} Copy", base);
+    let mut suffix = 2usize;
+    while presets.iter().any(|preset| preset.name == candidate) {
+        candidate = format!("{} Copy {}", base, suffix);
+        suffix += 1;
+    }
+    candidate
 }
 
 fn build_runner_report_csv(rows: &[RunnerResultRow]) -> String {


### PR DESCRIPTION
## Summary
- add serde-default-compatible saved Collection Runner presets to workspace state
- add runner modal controls to save, load, rename, duplicate, and delete presets
- store scope, active environment selection, and visible data rows without copying environment variable/cookie values
- fall back gracefully when saved folder or environment references are missing

## Tests
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

Closes #24