### PR TITLE
Add Collection Runner result detail drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Added
+- **Collection Runner result details.** Runner rows can now be selected
+  by mouse or keyboard to inspect method, redacted URL, collection
+  path, status, timing phases, assertion outcomes, and extractor
+  misses, with copy-safe summaries that keep response bodies, headers,
+  cookies, and extracted values out of reports and copied text.
+
 ## [0.23.0] — 2026-06-17
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod net;
 mod oauth;
 mod privacy;
 mod runner;
+mod runner_detail;
 mod snippet;
 mod sse;
 mod theme;
@@ -87,16 +88,7 @@ struct CachedResponse {
     assertion_results: Vec<Option<AssertionResult>>,
 }
 
-#[derive(Clone, Debug)]
-struct RunnerResultRow {
-    collection: String,
-    request: String,
-    method: HttpMethod,
-    url: String,
-    status: String,
-    duration_ms: Option<u64>,
-    note: String,
-}
+type RunnerResultRow = runner_detail::RunnerResultRow;
 
 struct ApiClient {
     state: AppState,
@@ -172,6 +164,7 @@ struct ApiClient {
     runner_scope_folder_id: Option<String>,
     runner_data_rows: String,
     runner_results: Vec<RunnerResultRow>,
+    runner_selected_result: Option<usize>,
     runner_status: String,
     runner_in_flight: Option<InFlightCollectionRun>,
 
@@ -474,6 +467,7 @@ impl Default for ApiClient {
             runner_scope_folder_id: None,
             runner_data_rows: String::new(),
             runner_results: Vec::new(),
+            runner_selected_result: None,
             runner_status: String::new(),
             runner_in_flight: None,
             show_snippet_panel: false,
@@ -2431,7 +2425,11 @@ impl eframe::App for ApiClient {
         while let Some(f) = &self.runner_in_flight {
             match f.rx.try_recv() {
                 Ok(runner::CollectionRunEvent::RequestFinished(progress)) => {
-                    self.runner_results.push(runner_progress_row(&progress));
+                    self.runner_results
+                        .push(runner_detail::row_from_progress(&progress));
+                    if self.runner_selected_result.is_none() {
+                        self.runner_selected_result = Some(0);
+                    }
                     self.runner_status = format!(
                         "Running: {} / {} request runs complete.",
                         progress.completed_requests, progress.total_requests
@@ -2439,7 +2437,13 @@ impl eframe::App for ApiClient {
                     ctx.request_repaint();
                 }
                 Ok(runner::CollectionRunEvent::Finished(result)) => {
-                    self.runner_results = runner_result_rows(&result);
+                    self.runner_results = runner_detail::rows_from_result(&result);
+                    if self
+                        .runner_selected_result
+                        .is_some_and(|index| index >= self.runner_results.len())
+                    {
+                        self.runner_selected_result = None;
+                    }
                     self.runner_status = format!(
                         "Finished: {} request run{}, {} passed, {} failed, {} errored.",
                         result.total_requests,
@@ -2506,86 +2510,6 @@ impl eframe::App for ApiClient {
         self.render_command_palette(ctx);
         self.render_actions_palette(ctx);
         self.render_toast(ctx);
-    }
-}
-
-fn runner_result_rows(result: &runner::CollectionRunResult) -> Vec<RunnerResultRow> {
-    let mut rows = Vec::new();
-    for iteration in &result.iterations {
-        let row_label = if iteration.data.is_empty() {
-            format!("Row {}", iteration.index + 1)
-        } else {
-            let keys = iteration
-                .data
-                .keys()
-                .take(3)
-                .cloned()
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("Row {} ({})", iteration.index + 1, keys)
-        };
-        for request in &iteration.requests {
-            let (passed, failed, errored) =
-                request.assertions.iter().fold((0, 0, 0), |acc, assertion| {
-                    match assertion.result {
-                        AssertionResult::Pass => (acc.0 + 1, acc.1, acc.2),
-                        AssertionResult::Fail(_) => (acc.0, acc.1 + 1, acc.2),
-                        AssertionResult::Error(_) => (acc.0, acc.1, acc.2 + 1),
-                    }
-                });
-            let mut note_parts = vec![format!(
-                "{} pass / {} fail / {} err",
-                passed, failed, errored
-            )];
-            if !request.extracted.is_empty() {
-                note_parts.push(format!("{} extracted", request.extracted.len()));
-            }
-            if !request.extractor_misses.is_empty() {
-                note_parts.push(format!("{} missed", request.extractor_misses.len()));
-            }
-            rows.push(RunnerResultRow {
-                collection: request.folder_path.join(" / "),
-                request: format!("{} · {}", row_label, request.request_name),
-                method: request.method.clone(),
-                url: privacy::redact_url_query_and_fragment(&request.url_template),
-                status: request.response.status.clone(),
-                duration_ms: Some(request.response.total_ms),
-                note: note_parts.join(", "),
-            });
-        }
-    }
-    rows
-}
-
-fn runner_progress_row(progress: &runner::RunnerRequestProgress) -> RunnerResultRow {
-    let row_label = runner_data_row_label(progress.iteration_index, &progress.data);
-    let mut note_parts = vec![format!(
-        "{} pass / {} fail / {} err",
-        progress.passed_assertions, progress.failed_assertions, progress.errored_assertions
-    )];
-    if progress.extracted_count > 0 {
-        note_parts.push(format!("{} extracted", progress.extracted_count));
-    }
-    if progress.extractor_miss_count > 0 {
-        note_parts.push(format!("{} missed", progress.extractor_miss_count));
-    }
-    RunnerResultRow {
-        collection: progress.collection.clone(),
-        request: format!("{} · {}", row_label, progress.request_name),
-        method: progress.method.clone(),
-        url: privacy::redact_url_query_and_fragment(&progress.url_template),
-        status: progress.status.clone(),
-        duration_ms: Some(progress.duration_ms),
-        note: note_parts.join(", "),
-    }
-}
-
-fn runner_data_row_label(index: usize, data: &runner::DataRow) -> String {
-    if data.is_empty() {
-        format!("Row {}", index + 1)
-    } else {
-        let keys = data.keys().take(3).cloned().collect::<Vec<_>>().join(", ");
-        format!("Row {} ({})", index + 1, keys)
     }
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -37,7 +37,7 @@ pub struct CollectionRunResult {
 }
 
 pub enum CollectionRunEvent {
-    RequestFinished(RunnerRequestProgress),
+    RequestFinished(Box<RunnerRequestProgress>),
     Finished(CollectionRunResult),
 }
 
@@ -53,11 +53,16 @@ pub struct RunnerRequestProgress {
     pub url_template: String,
     pub status: String,
     pub duration_ms: u64,
+    pub prepare_ms: u64,
+    pub waiting_ms: u64,
+    pub download_ms: u64,
     pub passed_assertions: usize,
     pub failed_assertions: usize,
     pub errored_assertions: usize,
+    pub assertions: Vec<AssertionRunResult>,
     pub extracted_count: usize,
     pub extractor_miss_count: usize,
+    pub extractor_misses: Vec<String>,
 }
 
 pub struct RunIterationResult {
@@ -195,23 +200,30 @@ async fn run_collection_inner(
 
             if let Some(progress) = &progress {
                 let (passed, failed, errored) = assertion_counts(&assertions);
-                let _ = progress.send(CollectionRunEvent::RequestFinished(RunnerRequestProgress {
-                    iteration_index: index,
-                    data: data.clone(),
-                    completed_requests: completed_runs,
-                    total_requests: total_runs,
-                    collection: runner_request.folder_path.join(" / "),
-                    request_name: runner_request.request.name.clone(),
-                    method: runner_request.request.method.clone(),
-                    url_template: runner_request.request.url.clone(),
-                    status: response.status.clone(),
-                    duration_ms: response.total_ms,
-                    passed_assertions: passed,
-                    failed_assertions: failed,
-                    errored_assertions: errored,
-                    extracted_count: extracted.len(),
-                    extractor_miss_count: extractor_misses.len(),
-                }));
+                let _ = progress.send(CollectionRunEvent::RequestFinished(Box::new(
+                    RunnerRequestProgress {
+                        iteration_index: index,
+                        data: data.clone(),
+                        completed_requests: completed_runs,
+                        total_requests: total_runs,
+                        collection: runner_request.folder_path.join(" / "),
+                        request_name: runner_request.request.name.clone(),
+                        method: runner_request.request.method.clone(),
+                        url_template: runner_request.request.url.clone(),
+                        status: response.status.clone(),
+                        duration_ms: response.total_ms,
+                        prepare_ms: response.prepare_ms,
+                        waiting_ms: response.waiting_ms,
+                        download_ms: response.download_ms,
+                        passed_assertions: passed,
+                        failed_assertions: failed,
+                        errored_assertions: errored,
+                        assertions: assertions.clone(),
+                        extracted_count: extracted.len(),
+                        extractor_miss_count: extractor_misses.len(),
+                        extractor_misses: extractor_misses.clone(),
+                    },
+                )));
             }
 
             let mut stored_response = response;

--- a/src/runner_detail.rs
+++ b/src/runner_detail.rs
@@ -1,0 +1,380 @@
+use crate::model::{AssertionResult, HttpMethod};
+use crate::{privacy, runner};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RunnerTimingDetail {
+    pub(crate) prepare_ms: u64,
+    pub(crate) waiting_ms: u64,
+    pub(crate) download_ms: u64,
+    pub(crate) total_ms: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum RunnerAssertionOutcome {
+    Pass,
+    Fail,
+    Error,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RunnerAssertionDetail {
+    pub(crate) index: usize,
+    pub(crate) outcome: RunnerAssertionOutcome,
+    pub(crate) message: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RunnerResultRow {
+    pub(crate) collection: String,
+    pub(crate) request: String,
+    pub(crate) request_name: String,
+    pub(crate) row_label: String,
+    pub(crate) method: HttpMethod,
+    pub(crate) url: String,
+    pub(crate) status: String,
+    pub(crate) duration_ms: Option<u64>,
+    pub(crate) timing: RunnerTimingDetail,
+    pub(crate) assertions: Vec<RunnerAssertionDetail>,
+    pub(crate) extracted_count: usize,
+    pub(crate) extractor_misses: Vec<String>,
+    pub(crate) note: String,
+}
+
+pub(crate) fn rows_from_result(result: &runner::CollectionRunResult) -> Vec<RunnerResultRow> {
+    let mut rows = Vec::new();
+    for iteration in &result.iterations {
+        let row_label = runner_data_row_label(iteration.index, &iteration.data);
+        for request in &iteration.requests {
+            rows.push(row_from_request_result(&row_label, request));
+        }
+    }
+    rows
+}
+
+pub(crate) fn row_from_progress(progress: &runner::RunnerRequestProgress) -> RunnerResultRow {
+    let row_label = runner_data_row_label(progress.iteration_index, &progress.data);
+    let assertions = assertion_details(&progress.assertions);
+    let note = result_note(
+        assertion_counts(&assertions),
+        progress.extracted_count,
+        progress.extractor_misses.len(),
+    );
+
+    RunnerResultRow {
+        collection: progress.collection.clone(),
+        request: format!("{} - {}", row_label, progress.request_name),
+        request_name: progress.request_name.clone(),
+        row_label,
+        method: progress.method.clone(),
+        url: privacy::redact_url_query_and_fragment(&progress.url_template),
+        status: progress.status.clone(),
+        duration_ms: Some(progress.duration_ms),
+        timing: RunnerTimingDetail {
+            prepare_ms: progress.prepare_ms,
+            waiting_ms: progress.waiting_ms,
+            download_ms: progress.download_ms,
+            total_ms: progress.duration_ms,
+        },
+        assertions,
+        extracted_count: progress.extracted_count,
+        extractor_misses: progress.extractor_misses.clone(),
+        note,
+    }
+}
+
+pub(crate) fn summary_text(row: &RunnerResultRow) -> String {
+    let (passed, failed, errored) = assertion_counts(&row.assertions);
+    let mut lines = vec![
+        format!("Request: {}", row.request),
+        format!("Collection: {}", empty_dash(&row.collection)),
+        format!("Method: {}", row.method),
+        format!("URL: {}", empty_dash(&row.url)),
+        format!("Status: {}", empty_dash(&row.status)),
+        format!("Total time: {}", duration_text(row.duration_ms)),
+        format!(
+            "Timings: prepare {} ms, waiting {} ms, download {} ms",
+            row.timing.prepare_ms, row.timing.waiting_ms, row.timing.download_ms
+        ),
+        format!(
+            "Assertions: {} pass / {} fail / {} error",
+            passed, failed, errored
+        ),
+        format!("Extracted values: {} value(s) hidden", row.extracted_count),
+        format!("Extractor misses: {}", row.extractor_misses.len()),
+    ];
+
+    if !row.extractor_misses.is_empty() {
+        lines.push(format!(
+            "Missing extractors: {}",
+            row.extractor_misses.join(", ")
+        ));
+    }
+
+    lines.join("\n")
+}
+
+pub(crate) fn duration_text(duration_ms: Option<u64>) -> String {
+    duration_ms
+        .map(|ms| format!("{} ms", ms))
+        .unwrap_or_else(|| "-".to_string())
+}
+
+fn row_from_request_result(row_label: &str, request: &runner::RequestRunResult) -> RunnerResultRow {
+    let assertions = assertion_details(&request.assertions);
+    let note = result_note(
+        assertion_counts(&assertions),
+        request.extracted.len(),
+        request.extractor_misses.len(),
+    );
+
+    RunnerResultRow {
+        collection: request.folder_path.join(" / "),
+        request: format!("{} - {}", row_label, request.request_name),
+        request_name: request.request_name.clone(),
+        row_label: row_label.to_string(),
+        method: request.method.clone(),
+        url: privacy::redact_url_query_and_fragment(&request.url_template),
+        status: request.response.status.clone(),
+        duration_ms: Some(request.response.total_ms),
+        timing: RunnerTimingDetail {
+            prepare_ms: request.response.prepare_ms,
+            waiting_ms: request.response.waiting_ms,
+            download_ms: request.response.download_ms,
+            total_ms: request.response.total_ms,
+        },
+        assertions,
+        extracted_count: request.extracted.len(),
+        extractor_misses: request.extractor_misses.clone(),
+        note,
+    }
+}
+
+fn runner_data_row_label(index: usize, data: &runner::DataRow) -> String {
+    if data.is_empty() {
+        format!("Row {}", index + 1)
+    } else {
+        let keys = data.keys().take(3).cloned().collect::<Vec<_>>().join(", ");
+        format!("Row {} ({})", index + 1, keys)
+    }
+}
+
+fn assertion_details(assertions: &[runner::AssertionRunResult]) -> Vec<RunnerAssertionDetail> {
+    assertions
+        .iter()
+        .map(|assertion| match &assertion.result {
+            AssertionResult::Pass => RunnerAssertionDetail {
+                index: assertion.index,
+                outcome: RunnerAssertionOutcome::Pass,
+                message: None,
+            },
+            AssertionResult::Fail(message) => RunnerAssertionDetail {
+                index: assertion.index,
+                outcome: RunnerAssertionOutcome::Fail,
+                message: Some(message.clone()),
+            },
+            AssertionResult::Error(message) => RunnerAssertionDetail {
+                index: assertion.index,
+                outcome: RunnerAssertionOutcome::Error,
+                message: Some(message.clone()),
+            },
+        })
+        .collect()
+}
+
+fn assertion_counts(assertions: &[RunnerAssertionDetail]) -> (usize, usize, usize) {
+    assertions
+        .iter()
+        .fold((0, 0, 0), |acc, assertion| match assertion.outcome {
+            RunnerAssertionOutcome::Pass => (acc.0 + 1, acc.1, acc.2),
+            RunnerAssertionOutcome::Fail => (acc.0, acc.1 + 1, acc.2),
+            RunnerAssertionOutcome::Error => (acc.0, acc.1, acc.2 + 1),
+        })
+}
+
+fn result_note(
+    (passed, failed, errored): (usize, usize, usize),
+    extracted_count: usize,
+    extractor_miss_count: usize,
+) -> String {
+    let mut note_parts = vec![format!(
+        "{} pass / {} fail / {} err",
+        passed, failed, errored
+    )];
+    if extracted_count > 0 {
+        note_parts.push(format!("{} extracted", extracted_count));
+    }
+    if extractor_miss_count > 0 {
+        note_parts.push(format!("{} missed", extractor_miss_count));
+    }
+    note_parts.join(", ")
+}
+
+fn empty_dash(value: &str) -> &str {
+    if value.is_empty() {
+        "-"
+    } else {
+        value
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ResponseData, StoredCookie};
+
+    fn response() -> ResponseData {
+        ResponseData {
+            body: "super-secret-body-token".to_string(),
+            status: "201 Created".to_string(),
+            time: "24 ms".to_string(),
+            headers: vec![(
+                "Authorization".to_string(),
+                "Bearer super-secret-header-token".to_string(),
+            )],
+            set_cookies: vec![StoredCookie {
+                name: "session".to_string(),
+                value: "super-secret-cookie".to_string(),
+                domain: "api.example.test".to_string(),
+                path: "/".to_string(),
+                expires: None,
+                secure: false,
+                http_only: true,
+            }],
+            response_headers_bytes: 10,
+            response_body_bytes: 20,
+            request_headers_bytes: 30,
+            request_body_bytes: 40,
+            prepare_ms: 2,
+            waiting_ms: 17,
+            download_ms: 5,
+            total_ms: 24,
+        }
+    }
+
+    #[test]
+    fn rows_from_result_redacts_url_and_keeps_detail_counts() {
+        let result = runner::CollectionRunResult {
+            iterations: vec![runner::RunIterationResult {
+                index: 0,
+                data: runner::DataRow::from([("password".to_string(), "hidden".to_string())]),
+                requests: vec![runner::RequestRunResult {
+                    request_id: "req-1".to_string(),
+                    request_name: "Login".to_string(),
+                    method: HttpMethod::POST,
+                    url_template: "https://api.example.test/login?token=secret#frag".to_string(),
+                    folder_path: vec!["Auth".to_string(), "Smoke".to_string()],
+                    response: response(),
+                    assertions: vec![
+                        runner::AssertionRunResult {
+                            index: 0,
+                            result: AssertionResult::Pass,
+                        },
+                        runner::AssertionRunResult {
+                            index: 1,
+                            result: AssertionResult::Fail("status mismatch".to_string()),
+                        },
+                        runner::AssertionRunResult {
+                            index: 2,
+                            result: AssertionResult::Error("bad body path".to_string()),
+                        },
+                    ],
+                    extracted: vec![("access_token".to_string(), "extracted-secret".to_string())],
+                    extractor_misses: vec!["refresh_token".to_string()],
+                }],
+            }],
+            total_requests: 1,
+            passed_assertions: 1,
+            failed_assertions: 1,
+            errored_assertions: 1,
+        };
+
+        let rows = rows_from_result(&result);
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+
+        assert_eq!(row.collection, "Auth / Smoke");
+        assert_eq!(row.request, "Row 1 (password) - Login");
+        assert_eq!(row.url, "https://api.example.test/login?...#...");
+        assert_eq!(row.timing.prepare_ms, 2);
+        assert_eq!(row.timing.waiting_ms, 17);
+        assert_eq!(row.timing.download_ms, 5);
+        assert_eq!(row.note, "1 pass / 1 fail / 1 err, 1 extracted, 1 missed");
+        assert_eq!(row.extractor_misses, vec!["refresh_token"]);
+        assert_eq!(row.extracted_count, 1);
+    }
+
+    #[test]
+    fn summary_text_omits_response_content_and_extracted_values() {
+        let result = runner::CollectionRunResult {
+            iterations: vec![runner::RunIterationResult {
+                index: 0,
+                data: runner::DataRow::new(),
+                requests: vec![runner::RequestRunResult {
+                    request_id: "req-1".to_string(),
+                    request_name: "Fetch Profile".to_string(),
+                    method: HttpMethod::GET,
+                    url_template: "https://api.example.test/profile?api_key=query-secret"
+                        .to_string(),
+                    folder_path: vec!["Users".to_string()],
+                    response: response(),
+                    assertions: vec![],
+                    extracted: vec![("profile_token".to_string(), "extracted-secret".to_string())],
+                    extractor_misses: vec!["profile_id".to_string()],
+                }],
+            }],
+            total_requests: 1,
+            passed_assertions: 0,
+            failed_assertions: 0,
+            errored_assertions: 0,
+        };
+
+        let row = rows_from_result(&result).remove(0);
+        let summary = summary_text(&row);
+
+        assert!(summary.contains("https://api.example.test/profile?..."));
+        assert!(summary.contains("Extracted values: 1 value(s) hidden"));
+        assert!(summary.contains("Missing extractors: profile_id"));
+        assert!(!summary.contains("query-secret"));
+        assert!(!summary.contains("super-secret-body-token"));
+        assert!(!summary.contains("super-secret-header-token"));
+        assert!(!summary.contains("super-secret-cookie"));
+        assert!(!summary.contains("extracted-secret"));
+    }
+
+    #[test]
+    fn row_from_progress_preserves_live_detail_without_values() {
+        let progress = runner::RunnerRequestProgress {
+            iteration_index: 1,
+            data: runner::DataRow::from([("user".to_string(), "alice".to_string())]),
+            completed_requests: 2,
+            total_requests: 3,
+            collection: "Auth".to_string(),
+            request_name: "Login".to_string(),
+            method: HttpMethod::POST,
+            url_template: "https://api.example.test/login?password=secret".to_string(),
+            status: "500 Internal Server Error".to_string(),
+            duration_ms: 42,
+            prepare_ms: 3,
+            waiting_ms: 37,
+            download_ms: 2,
+            passed_assertions: 0,
+            failed_assertions: 1,
+            errored_assertions: 0,
+            assertions: vec![runner::AssertionRunResult {
+                index: 0,
+                result: AssertionResult::Fail("status mismatch".to_string()),
+            }],
+            extracted_count: 1,
+            extractor_miss_count: 1,
+            extractor_misses: vec!["token".to_string()],
+        };
+
+        let row = row_from_progress(&progress);
+
+        assert_eq!(row.request, "Row 2 (user) - Login");
+        assert_eq!(row.url, "https://api.example.test/login?...");
+        assert_eq!(row.note, "0 pass / 1 fail / 0 err, 1 extracted, 1 missed");
+        assert_eq!(row.assertions[0].outcome, RunnerAssertionOutcome::Fail);
+        assert_eq!(row.extractor_misses, vec!["token"]);
+    }
+}

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -10,8 +10,8 @@ use crate::snippet::{build_snippet_layout_job_content_only, render_snippet, Snip
 use crate::theme::*;
 use crate::widgets::*;
 use crate::{
-    backup, in_app_update_supported, open_update_log_in_os, runner, spawn_update_check,
-    update_log_path, ApiClient, RunnerResultRow, UpdateCheckOutcome,
+    backup, in_app_update_supported, open_update_log_in_os, runner, runner_detail,
+    spawn_update_check, update_log_path, ApiClient, RunnerResultRow, UpdateCheckOutcome,
 };
 use eframe::egui;
 use std::path::PathBuf;
@@ -1087,7 +1087,15 @@ impl ApiClient {
         let mut cancel_requested = false;
         let mut export_csv_requested = false;
         let mut export_html_requested = false;
+        let mut copy_summary_requested: Option<String> = None;
         let runner_busy = self.runner_in_flight.is_some();
+        if self
+            .runner_selected_result
+            .is_some_and(|index| index >= self.runner_results.len())
+        {
+            self.runner_selected_result = None;
+        }
+        let mut selected_result = self.runner_selected_result;
 
         egui::Window::new("Collection Runner")
             .open(&mut open)
@@ -1259,6 +1267,21 @@ impl ApiClient {
                                     {
                                         export_csv_requested = true;
                                     }
+                                    let can_copy = selected_result
+                                        .and_then(|index| self.runner_results.get(index))
+                                        .is_some();
+                                    if ui
+                                        .add_enabled(can_copy, egui::Button::new("Copy Summary"))
+                                        .on_hover_text("Copy a secret-safe summary for the selected result")
+                                        .clicked()
+                                    {
+                                        if let Some(row) = selected_result
+                                            .and_then(|index| self.runner_results.get(index))
+                                        {
+                                            copy_summary_requested =
+                                                Some(runner_detail::summary_text(row));
+                                        }
+                                    }
                                 },
                             );
                         });
@@ -1312,27 +1335,54 @@ impl ApiClient {
                                             ui.label("");
                                             ui.end_row();
                                         } else {
-                                            for row in &self.runner_results {
-                                                ui.label(&row.collection);
-                                                ui.label(&row.request);
-                                                ui.label(row.method.to_string());
-                                                ui.label(&row.status);
-                                                ui.label(
-                                                    row.duration_ms
-                                                        .map(|ms| format!("{} ms", ms))
-                                                        .unwrap_or_else(|| "-".to_string()),
+                                            for (index, row) in self.runner_results.iter().enumerate()
+                                            {
+                                                let selected = selected_result == Some(index);
+                                                let mut choose = false;
+                                                choose |= runner_result_cell(
+                                                    ui,
+                                                    selected,
+                                                    &row.collection,
                                                 );
-                                                ui.label(&row.note);
+                                                choose |= runner_result_cell(
+                                                    ui,
+                                                    selected,
+                                                    &row.request,
+                                                );
+                                                choose |= runner_result_cell(
+                                                    ui,
+                                                    selected,
+                                                    &row.method.to_string(),
+                                                );
+                                                choose |=
+                                                    runner_result_cell(ui, selected, &row.status);
+                                                choose |= runner_result_cell(
+                                                    ui,
+                                                    selected,
+                                                    &runner_detail::duration_text(row.duration_ms),
+                                                );
+                                                choose |=
+                                                    runner_result_cell(ui, selected, &row.note);
+                                                if choose {
+                                                    selected_result = Some(index);
+                                                }
                                                 ui.end_row();
                                             }
                                         }
                                     });
                             });
+                        if let Some(row) =
+                            selected_result.and_then(|index| self.runner_results.get(index))
+                        {
+                            ui.add_space(10.0);
+                            render_runner_detail_panel(ui, row);
+                        }
                     });
                 });
             });
 
         self.show_runner_modal = open;
+        self.runner_selected_result = selected_result;
 
         if run_requested {
             self.start_collection_runner();
@@ -1348,6 +1398,10 @@ impl ApiClient {
         }
         if export_html_requested {
             self.export_runner_report("html");
+        }
+        if let Some(summary) = copy_summary_requested {
+            ctx.copy_text(summary);
+            self.show_toast("Runner summary copied");
         }
     }
 
@@ -1406,6 +1460,7 @@ impl ApiClient {
         });
         self.runner_in_flight = Some(crate::InFlightCollectionRun { handle, rx });
         self.runner_results.clear();
+        self.runner_selected_result = None;
         self.runner_status = format!(
             "Running {} request{} across {} iteration{}...",
             request_count,
@@ -3066,6 +3121,150 @@ fn build_runner_report_html(rows: &[RunnerResultRow]) -> String {
     }
     out.push_str("</tbody></table></body></html>");
     out
+}
+
+fn runner_result_cell(ui: &mut egui::Ui, selected: bool, value: &str) -> bool {
+    let resp = ui
+        .selectable_label(selected, egui::RichText::new(value).color(text()))
+        .on_hover_cursor(egui::CursorIcon::PointingHand);
+    let keyboard_select = resp.has_focus()
+        && ui.input(|i| i.key_pressed(egui::Key::Enter) || i.key_pressed(egui::Key::Space));
+    resp.clicked() || keyboard_select
+}
+
+fn render_runner_detail_panel(ui: &mut egui::Ui, row: &RunnerResultRow) {
+    egui::Frame::none()
+        .fill(elevated())
+        .stroke(egui::Stroke::new(1.0, border()))
+        .rounding(6.0)
+        .inner_margin(egui::Margin::same(10.0))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label(
+                    egui::RichText::new("Result Detail")
+                        .size(11.0)
+                        .strong()
+                        .color(muted()),
+                );
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    ui.label(
+                        egui::RichText::new("body, headers, cookies, and extracted values hidden")
+                            .size(11.0)
+                            .color(muted()),
+                    );
+                });
+            });
+            ui.add_space(8.0);
+
+            egui::Grid::new("runner_result_detail_grid")
+                .num_columns(2)
+                .spacing(egui::vec2(12.0, 4.0))
+                .show(ui, |ui| {
+                    runner_detail_kv(ui, "Method", &row.method.to_string());
+                    runner_detail_kv(ui, "URL", &row.url);
+                    runner_detail_kv(ui, "Collection", &row.collection);
+                    runner_detail_kv(ui, "Data row", &row.row_label);
+                    runner_detail_kv(ui, "Request", &row.request_name);
+                    runner_detail_kv(ui, "Status", &row.status);
+                    runner_detail_kv(
+                        ui,
+                        "Timing",
+                        &format!(
+                            "{} ms total, {} ms prepare, {} ms waiting, {} ms download",
+                            row.timing.total_ms,
+                            row.timing.prepare_ms,
+                            row.timing.waiting_ms,
+                            row.timing.download_ms
+                        ),
+                    );
+                    runner_detail_kv(
+                        ui,
+                        "Extracted",
+                        &format!("{} value(s) hidden", row.extracted_count),
+                    );
+                });
+
+            ui.add_space(8.0);
+            ui.separator();
+            ui.add_space(8.0);
+
+            ui.horizontal(|ui| {
+                ui.vertical(|ui| {
+                    ui.set_min_width(260.0);
+                    ui.label(
+                        egui::RichText::new("Assertions")
+                            .size(11.0)
+                            .strong()
+                            .color(muted()),
+                    );
+                    ui.add_space(4.0);
+                    if row.assertions.is_empty() {
+                        ui.label(egui::RichText::new("No assertions ran").color(muted()));
+                    } else {
+                        for assertion in &row.assertions {
+                            let (label, color) = match assertion.outcome {
+                                runner_detail::RunnerAssertionOutcome::Pass => ("PASS", C_GREEN),
+                                runner_detail::RunnerAssertionOutcome::Fail => ("FAIL", C_RED),
+                                runner_detail::RunnerAssertionOutcome::Error => ("ERROR", C_ORANGE),
+                            };
+                            ui.horizontal_wrapped(|ui| {
+                                ui.label(
+                                    egui::RichText::new(label)
+                                        .font(egui::FontId::monospace(11.0))
+                                        .strong()
+                                        .color(color),
+                                );
+                                ui.label(
+                                    egui::RichText::new(format!("#{}", assertion.index + 1))
+                                        .font(egui::FontId::monospace(11.0))
+                                        .color(muted()),
+                                );
+                                if let Some(message) = &assertion.message {
+                                    ui.label(
+                                        egui::RichText::new(message)
+                                            .font(egui::FontId::monospace(11.0))
+                                            .color(text()),
+                                    );
+                                }
+                            });
+                        }
+                    }
+                });
+
+                ui.separator();
+
+                ui.vertical(|ui| {
+                    ui.label(
+                        egui::RichText::new("Extractor Misses")
+                            .size(11.0)
+                            .strong()
+                            .color(muted()),
+                    );
+                    ui.add_space(4.0);
+                    if row.extractor_misses.is_empty() {
+                        ui.label(egui::RichText::new("No extractor misses").color(muted()));
+                    } else {
+                        for miss in &row.extractor_misses {
+                            ui.label(
+                                egui::RichText::new(miss)
+                                    .font(egui::FontId::monospace(11.0))
+                                    .color(text()),
+                            );
+                        }
+                    }
+                });
+            });
+        });
+}
+
+fn runner_detail_kv(ui: &mut egui::Ui, label: &str, value: &str) {
+    ui.label(egui::RichText::new(label).size(11.0).color(muted()));
+    ui.label(
+        egui::RichText::new(if value.is_empty() { "-" } else { value })
+            .size(12.0)
+            .color(text()),
+    );
+    ui.end_row();
 }
 
 fn csv_cell(value: &str) -> String {


### PR DESCRIPTION
## Summary
- add pure runner result detail and copy-summary conversion helpers
- show selectable Collection Runner result details with timing phases, assertion outcomes, and extractor misses
- keep summaries/reports secret-safe by omitting response bodies, headers, cookies, and extracted values

## Tests
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features

Closes #25