### PR TITLE
Add environment compare modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## [Unreleased]
+
+### Added
+- **Environment compare.** The environment manager can now compare a
+  source and target environment, group added/missing/changed/unchanged
+  variable keys, mask sensitive-looking values by default, copy a safe
+  summary, and add missing source keys to the target.
+
 ## [0.23.0] — 2026-06-17
 
 ### Added

--- a/src/env_compare.rs
+++ b/src/env_compare.rs
@@ -1,0 +1,265 @@
+use crate::model::{Environment, KvRow};
+use crate::privacy::{is_sensitive_key, mask_secret_value};
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EnvValue {
+    pub value: String,
+    pub enabled: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EnvDiffEntry {
+    pub key: String,
+    pub source: Option<EnvValue>,
+    pub target: Option<EnvValue>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EnvDiff {
+    pub added: Vec<EnvDiffEntry>,
+    pub missing: Vec<EnvDiffEntry>,
+    pub changed: Vec<EnvDiffEntry>,
+    pub unchanged: Vec<EnvDiffEntry>,
+}
+
+impl EnvDiff {
+    pub fn is_empty(&self) -> bool {
+        self.added.is_empty()
+            && self.missing.is_empty()
+            && self.changed.is_empty()
+            && self.unchanged.is_empty()
+    }
+}
+
+pub fn compare_environments(source: &Environment, target: &Environment) -> EnvDiff {
+    compare_variable_rows(&source.variables, &target.variables)
+}
+
+fn compare_variable_rows(source: &[KvRow], target: &[KvRow]) -> EnvDiff {
+    let source_map = keyed_values(source);
+    let target_map = keyed_values(target);
+    let keys: BTreeSet<&str> = source_map
+        .keys()
+        .chain(target_map.keys())
+        .map(String::as_str)
+        .collect();
+    let mut diff = EnvDiff::default();
+
+    for key in keys {
+        let source = source_map.get(key).cloned();
+        let target = target_map.get(key).cloned();
+        let entry = EnvDiffEntry {
+            key: key.to_string(),
+            source,
+            target,
+        };
+        match (&entry.source, &entry.target) {
+            (Some(_), None) => diff.missing.push(entry),
+            (None, Some(_)) => diff.added.push(entry),
+            (Some(source), Some(target)) if source == target => diff.unchanged.push(entry),
+            (Some(_), Some(_)) => diff.changed.push(entry),
+            (None, None) => {}
+        }
+    }
+
+    diff
+}
+
+pub fn display_value(key: &str, value: &str) -> String {
+    if is_sensitive_key(key) {
+        mask_secret_value(value)
+    } else {
+        value.to_string()
+    }
+}
+
+pub fn safe_summary(source_name: &str, target_name: &str, diff: &EnvDiff) -> String {
+    let mut out = String::new();
+    let _ = writeln!(out, "Environment diff: {} -> {}", source_name, target_name);
+    let _ = writeln!(
+        out,
+        "Added: {} | Missing: {} | Changed: {} | Unchanged: {}",
+        diff.added.len(),
+        diff.missing.len(),
+        diff.changed.len(),
+        diff.unchanged.len()
+    );
+    write_group(&mut out, "Added in target", &diff.added);
+    write_group(&mut out, "Missing from target", &diff.missing);
+    write_group(&mut out, "Changed", &diff.changed);
+    write_group(&mut out, "Unchanged", &diff.unchanged);
+    out
+}
+
+fn keyed_values(rows: &[KvRow]) -> BTreeMap<String, EnvValue> {
+    let mut values = BTreeMap::new();
+    for row in rows {
+        let key = row.key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        values.entry(key.to_string()).or_insert_with(|| EnvValue {
+            value: row.value.clone(),
+            enabled: row.enabled,
+        });
+    }
+    values
+}
+
+fn write_group(out: &mut String, title: &str, entries: &[EnvDiffEntry]) {
+    if entries.is_empty() {
+        return;
+    }
+
+    let _ = writeln!(out);
+    let _ = writeln!(out, "{}:", title);
+    for entry in entries {
+        match (&entry.source, &entry.target) {
+            (Some(source), Some(target)) => {
+                let _ = writeln!(
+                    out,
+                    "- {}: {} -> {}{}",
+                    entry.key,
+                    display_value(&entry.key, &source.value),
+                    display_value(&entry.key, &target.value),
+                    enabled_note(source.enabled, target.enabled)
+                );
+            }
+            (Some(source), None) => {
+                let _ = writeln!(
+                    out,
+                    "- {}: {}{}",
+                    entry.key,
+                    display_value(&entry.key, &source.value),
+                    if source.enabled { "" } else { " (disabled)" }
+                );
+            }
+            (None, Some(target)) => {
+                let _ = writeln!(
+                    out,
+                    "- {}: {}{}",
+                    entry.key,
+                    display_value(&entry.key, &target.value),
+                    if target.enabled { "" } else { " (disabled)" }
+                );
+            }
+            (None, None) => {}
+        }
+    }
+}
+
+fn enabled_note(source_enabled: bool, target_enabled: bool) -> String {
+    if source_enabled == target_enabled {
+        String::new()
+    } else {
+        format!(
+            " ({} -> {})",
+            if source_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            if target_enabled {
+                "enabled"
+            } else {
+                "disabled"
+            }
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(name: &str, rows: Vec<KvRow>) -> Environment {
+        Environment {
+            id: name.to_string(),
+            name: name.to_string(),
+            variables: rows,
+            cookies: vec![],
+        }
+    }
+
+    #[test]
+    fn groups_added_missing_changed_and_unchanged_keys() {
+        let source = env(
+            "Local",
+            vec![
+                KvRow::new("API_URL", "http://localhost"),
+                KvRow::new("TIMEOUT", "30"),
+                KvRow::new("SOURCE_ONLY", "copy-me"),
+            ],
+        );
+        let target = env(
+            "Prod",
+            vec![
+                KvRow::new("API_URL", "https://api.example.com"),
+                KvRow::new("TIMEOUT", "30"),
+                KvRow::new("TARGET_ONLY", "already-there"),
+            ],
+        );
+
+        let diff = compare_environments(&source, &target);
+
+        assert_eq!(
+            diff.changed
+                .iter()
+                .map(|e| e.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["API_URL"]
+        );
+        assert_eq!(
+            diff.unchanged
+                .iter()
+                .map(|e| e.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["TIMEOUT"]
+        );
+        assert_eq!(
+            diff.missing
+                .iter()
+                .map(|e| e.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["SOURCE_ONLY"]
+        );
+        assert_eq!(
+            diff.added
+                .iter()
+                .map(|e| e.key.as_str())
+                .collect::<Vec<_>>(),
+            vec!["TARGET_ONLY"]
+        );
+    }
+
+    #[test]
+    fn masks_sensitive_values_in_display_and_summary() {
+        let source = env("Local", vec![KvRow::new("api_token", "super-secret-token")]);
+        let target = env("Prod", vec![KvRow::new("api_token", "different-secret")]);
+        let diff = compare_environments(&source, &target);
+        let summary = safe_summary("Local", "Prod", &diff);
+
+        assert_eq!(
+            display_value("api_token", "super-secret-token"),
+            "super-...oken"
+        );
+        assert!(summary.contains("api_token: super-...oken -> differ...cret"));
+        assert!(!summary.contains("super-secret-token"));
+        assert!(!summary.contains("different-secret"));
+    }
+
+    #[test]
+    fn enabled_state_changes_count_as_changed() {
+        let mut source_row = KvRow::new("FEATURE", "on");
+        source_row.enabled = true;
+        let mut target_row = KvRow::new("FEATURE", "on");
+        target_row.enabled = false;
+
+        let diff = compare_environments(&env("A", vec![source_row]), &env("B", vec![target_row]));
+
+        assert_eq!(diff.changed.len(), 1);
+        assert!(safe_summary("A", "B", &diff).contains("(enabled -> disabled)"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod assertion;
 mod backup;
 mod cookies;
 mod diff;
+mod env_compare;
 mod extract;
 mod html_preview;
 mod icon;
@@ -196,6 +197,8 @@ struct ApiClient {
     sidebar_view: SidebarView,
     show_env_modal: bool,
     selected_env_for_edit: Option<String>,
+    env_compare_source_id: Option<String>,
+    env_compare_target_id: Option<String>,
 
     toast: Option<(String, f32)>,
     focus_search_next_frame: bool,
@@ -484,6 +487,8 @@ impl Default for ApiClient {
             sidebar_view: SidebarView::Collections,
             show_env_modal: false,
             selected_env_for_edit: None,
+            env_compare_source_id: None,
+            env_compare_target_id: None,
             toast: None,
             focus_search_next_frame: false,
             app_icon: None,

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -4,6 +4,7 @@
 //! of state helpers tightly coupled to the save-draft modal
 //! (folder-path lookup, subtree search) and `new_draft_request`.
 
+use crate::env_compare::{compare_environments, display_value, safe_summary, EnvDiffEntry};
 use crate::io::curl;
 use crate::model::*;
 use crate::snippet::{build_snippet_layout_job_content_only, render_snippet, SnippetLang};
@@ -158,13 +159,17 @@ impl ApiClient {
         let mut close_modal = false;
         let mut create_env = false;
         let mut delete_id: Option<String> = None;
+        let mut add_missing_key: Option<(String, KvRow)> = None;
+        let mut copy_summary: Option<String> = None;
+
+        self.normalize_env_compare_selection();
 
         egui::Window::new("Environments")
             .open(&mut open)
             .collapsible(false)
             .resizable(true)
-            .default_width(560.0)
-            .default_height(420.0)
+            .default_width(760.0)
+            .default_height(560.0)
             .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
             .show(ctx, |ui| {
                 ui.horizontal(|ui| {
@@ -206,7 +211,7 @@ impl ApiClient {
 
                     ui.separator();
 
-                    // Right column: editor for selected env
+                    // Right column: editor for selected env + compare.
                     ui.vertical(|ui| {
                         let id = self.selected_env_for_edit.clone();
                         let env_idx = id.as_ref().and_then(|id| {
@@ -254,6 +259,10 @@ impl ApiClient {
                                 self.state.environments[idx].variables = vars;
                                 self.save_state();
                             }
+
+                            ui.add_space(12.0);
+                            ui.separator();
+                            ui.add_space(8.0);
                         } else {
                             ui.label(
                                 egui::RichText::new(
@@ -261,6 +270,130 @@ impl ApiClient {
                                 )
                                 .color(muted()),
                             );
+                            ui.add_space(12.0);
+                            ui.separator();
+                            ui.add_space(8.0);
+                        }
+
+                        ui.label(
+                            egui::RichText::new("Compare environments")
+                                .size(11.0)
+                                .strong()
+                                .color(muted()),
+                        );
+                        ui.add_space(4.0);
+
+                        if self.state.environments.len() < 2 {
+                            ui.label(
+                                egui::RichText::new(
+                                    "Create at least two environments to compare variables.",
+                                )
+                                .color(muted()),
+                            );
+                        } else {
+                            ui.horizontal(|ui| {
+                                env_combo(
+                                    ui,
+                                    "env_compare_source",
+                                    "Source",
+                                    &self.state.environments,
+                                    &mut self.env_compare_source_id,
+                                );
+                                env_combo(
+                                    ui,
+                                    "env_compare_target",
+                                    "Target",
+                                    &self.state.environments,
+                                    &mut self.env_compare_target_id,
+                                );
+                                if ui.button("Swap").clicked() {
+                                    std::mem::swap(
+                                        &mut self.env_compare_source_id,
+                                        &mut self.env_compare_target_id,
+                                    );
+                                }
+                            });
+                            ui.add_space(6.0);
+
+                            let source_env = self
+                                .env_compare_source_id
+                                .as_ref()
+                                .and_then(|id| self.state.environments.iter().find(|e| &e.id == id))
+                                .cloned();
+                            let target_env = self
+                                .env_compare_target_id
+                                .as_ref()
+                                .and_then(|id| self.state.environments.iter().find(|e| &e.id == id))
+                                .cloned();
+
+                            if let (Some(source), Some(target)) = (source_env, target_env) {
+                                let diff = compare_environments(&source, &target);
+                                ui.horizontal_wrapped(|ui| {
+                                    diff_badge(ui, "Added", diff.added.len(), C_GREEN);
+                                    diff_badge(ui, "Missing", diff.missing.len(), C_ORANGE);
+                                    diff_badge(ui, "Changed", diff.changed.len(), accent());
+                                    diff_badge(ui, "Unchanged", diff.unchanged.len(), muted());
+                                    if ui.button("Copy safe summary").clicked() {
+                                        copy_summary =
+                                            Some(safe_summary(&source.name, &target.name, &diff));
+                                    }
+                                });
+                                ui.add_space(6.0);
+
+                                if source.id == target.id {
+                                    ui.label(
+                                        egui::RichText::new(
+                                            "Pick two different environments for a useful diff.",
+                                        )
+                                        .color(muted()),
+                                    );
+                                } else if diff.is_empty() {
+                                    ui.label(
+                                        egui::RichText::new(
+                                            "No variable keys in either environment.",
+                                        )
+                                        .color(muted()),
+                                    );
+                                } else {
+                                    egui::ScrollArea::vertical()
+                                        .id_salt("env_compare_scroll")
+                                        .max_height(220.0)
+                                        .show(ui, |ui| {
+                                            render_env_diff_group(
+                                                ui,
+                                                "Missing from target",
+                                                &diff.missing,
+                                                C_ORANGE,
+                                                Some((&target.id, &source.name)),
+                                                &mut add_missing_key,
+                                            );
+                                            render_env_diff_group(
+                                                ui,
+                                                "Added in target",
+                                                &diff.added,
+                                                C_GREEN,
+                                                None,
+                                                &mut add_missing_key,
+                                            );
+                                            render_env_diff_group(
+                                                ui,
+                                                "Changed",
+                                                &diff.changed,
+                                                accent(),
+                                                None,
+                                                &mut add_missing_key,
+                                            );
+                                            render_env_diff_group(
+                                                ui,
+                                                "Unchanged",
+                                                &diff.unchanged,
+                                                muted(),
+                                                None,
+                                                &mut add_missing_key,
+                                            );
+                                        });
+                                }
+                            }
                         }
                     });
                 });
@@ -295,6 +428,7 @@ impl ApiClient {
             let new_id = new.id.clone();
             self.state.environments.push(new);
             self.selected_env_for_edit = Some(new_id);
+            self.normalize_env_compare_selection();
             self.save_state();
         }
         if let Some(id) = delete_id {
@@ -305,11 +439,75 @@ impl ApiClient {
             if self.selected_env_for_edit.as_deref() == Some(&id) {
                 self.selected_env_for_edit = self.state.environments.first().map(|e| e.id.clone());
             }
+            if self.env_compare_source_id.as_deref() == Some(&id) {
+                self.env_compare_source_id = None;
+            }
+            if self.env_compare_target_id.as_deref() == Some(&id) {
+                self.env_compare_target_id = None;
+            }
+            self.normalize_env_compare_selection();
             self.save_state();
+        }
+        if let Some((target_id, row)) = add_missing_key {
+            if let Some(env) = self
+                .state
+                .environments
+                .iter_mut()
+                .find(|env| env.id == target_id)
+            {
+                env.variables.push(row);
+                self.save_state();
+                self.show_toast("Missing environment key added");
+            }
+        }
+        if let Some(summary) = copy_summary {
+            ctx.copy_text(summary);
+            self.show_toast("Environment diff summary copied");
         }
         if close_modal {
             self.show_env_modal = false;
         }
+    }
+
+    fn normalize_env_compare_selection(&mut self) {
+        let ids: Vec<String> = self
+            .state
+            .environments
+            .iter()
+            .map(|env| env.id.clone())
+            .collect();
+        if ids.is_empty() {
+            self.env_compare_source_id = None;
+            self.env_compare_target_id = None;
+            return;
+        }
+
+        let preferred_source = self
+            .env_compare_source_id
+            .clone()
+            .filter(|id| ids.contains(id))
+            .or_else(|| {
+                self.state
+                    .active_env_id
+                    .clone()
+                    .filter(|id| ids.contains(id))
+            })
+            .or_else(|| {
+                self.selected_env_for_edit
+                    .clone()
+                    .filter(|id| ids.contains(id))
+            })
+            .unwrap_or_else(|| ids[0].clone());
+
+        let preferred_target = self
+            .env_compare_target_id
+            .clone()
+            .filter(|id| ids.contains(id) && id != &preferred_source)
+            .or_else(|| ids.iter().find(|id| *id != &preferred_source).cloned())
+            .unwrap_or_else(|| preferred_source.clone());
+
+        self.env_compare_source_id = Some(preferred_source);
+        self.env_compare_target_id = Some(preferred_target);
     }
 
     pub(crate) fn begin_save_draft(&mut self, idx: usize) {
@@ -2947,6 +3145,143 @@ struct RunnerScopeOption {
     name: String,
     depth: usize,
     request_count: usize,
+}
+
+fn env_combo(
+    ui: &mut egui::Ui,
+    id_salt: &str,
+    label: &str,
+    envs: &[Environment],
+    selected_id: &mut Option<String>,
+) {
+    let selected_name = selected_id
+        .as_ref()
+        .and_then(|id| envs.iter().find(|env| &env.id == id))
+        .map(|env| env.name.as_str())
+        .unwrap_or("Select");
+
+    ui.label(egui::RichText::new(label).size(11.0).color(muted()));
+    egui::ComboBox::from_id_salt(id_salt)
+        .selected_text(selected_name)
+        .width(170.0)
+        .show_ui(ui, |ui| {
+            for env in envs {
+                let selected = selected_id.as_deref() == Some(env.id.as_str());
+                if ui.selectable_label(selected, &env.name).clicked() {
+                    *selected_id = Some(env.id.clone());
+                }
+            }
+        });
+}
+
+fn diff_badge(ui: &mut egui::Ui, label: &str, count: usize, color: egui::Color32) {
+    ui.label(
+        egui::RichText::new(format!("{} {}", label, count))
+            .size(11.0)
+            .color(color)
+            .strong(),
+    );
+}
+
+fn render_env_diff_group(
+    ui: &mut egui::Ui,
+    title: &str,
+    entries: &[EnvDiffEntry],
+    color: egui::Color32,
+    add_target: Option<(&str, &str)>,
+    add_missing_key: &mut Option<(String, KvRow)>,
+) {
+    if entries.is_empty() {
+        return;
+    }
+
+    egui::CollapsingHeader::new(
+        egui::RichText::new(format!("{} ({})", title, entries.len()))
+            .size(12.0)
+            .strong()
+            .color(color),
+    )
+    .default_open(!matches!(title, "Unchanged"))
+    .show(ui, |ui| {
+        for entry in entries {
+            egui::Frame::none()
+                .fill(with_alpha(
+                    if matches!(title, "Unchanged") {
+                        border()
+                    } else {
+                        color
+                    },
+                    if is_light() { 12 } else { 18 },
+                ))
+                .rounding(egui::Rounding::same(6.0))
+                .inner_margin(egui::Margin::symmetric(8.0, 5.0))
+                .show(ui, |ui| {
+                    ui.horizontal_wrapped(|ui| {
+                        ui.add_sized(
+                            [150.0, 18.0],
+                            egui::Label::new(
+                                egui::RichText::new(&entry.key)
+                                    .monospace()
+                                    .size(12.0)
+                                    .color(text()),
+                            ),
+                        );
+                        ui.label(
+                            egui::RichText::new(env_entry_value(entry))
+                                .size(12.0)
+                                .color(muted()),
+                        );
+                        if let (Some((target_id, source_name)), Some(source)) =
+                            (add_target, entry.source.as_ref())
+                        {
+                            if ui.button("Add to target").clicked() {
+                                *add_missing_key = Some((
+                                    target_id.to_string(),
+                                    KvRow {
+                                        enabled: source.enabled,
+                                        key: entry.key.clone(),
+                                        value: source.value.clone(),
+                                        description: format!("Added from {}", source_name),
+                                    },
+                                ));
+                            }
+                        }
+                    });
+                });
+            ui.add_space(3.0);
+        }
+    });
+}
+
+fn env_entry_value(entry: &EnvDiffEntry) -> String {
+    match (&entry.source, &entry.target) {
+        (Some(source), Some(target)) => format!(
+            "{}{} -> {}{}",
+            display_value(&entry.key, &source.value),
+            enabled_suffix(source.enabled),
+            display_value(&entry.key, &target.value),
+            enabled_suffix(target.enabled)
+        ),
+        (Some(source), None) => format!(
+            "{}{}",
+            display_value(&entry.key, &source.value),
+            enabled_suffix(source.enabled)
+        ),
+        (None, Some(target)) => format!(
+            "{}{}",
+            display_value(&entry.key, &target.value),
+            enabled_suffix(target.enabled)
+        ),
+        (None, None) => String::new(),
+    }
+}
+
+fn enabled_suffix(enabled: bool) -> &'static str {
+    if enabled {
+        ""
+    } else {
+        " (disabled)"
+    }
 }
 
 fn count_runner_requests(folders: &[Folder], folder_id: Option<&str>) -> usize {


### PR DESCRIPTION
## Summary
- add a pure environment diff helper with grouped added, missing, changed, and unchanged keys
- add source/target compare UI to the environments modal with masked sensitive values and safe summary copy
- allow missing source keys to be added to the target environment

## Tests
- cargo fmt
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

Closes #26