### PR TITLE
Add redacted snippet and cURL copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## [Unreleased]
+
+### Changed
+- **Code snippet sharing is redacted by default.** cURL, Python
+  `requests`, JavaScript `fetch`, and HTTPie exports now preserve
+  request shape while masking authorization, cookie, sensitive query,
+  and sensitive body values. The snippet panel keeps an explicit
+  **Copy raw** action for intentional unredacted copies.
+
 ## [0.23.0] — 2026-06-17
 
 ### Added

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -139,8 +139,10 @@ who'd rather use a dedicated dialog.
 
 Click **`</> Code`** next to Send. A **right-side code panel** opens with a
 language picker (cURL · Python `requests` · JavaScript `fetch` · HTTPie). The
-code respects which headers / params / cookies you've enabled. Click **Copy**
-to grab it.
+code respects which headers / params / cookies you've enabled. The displayed
+snippet and main copy action redact authorization, cookie, sensitive query, and
+sensitive body values for sharing; use **Copy raw** in the panel when you need
+the original values.
 
 ### Importing / exporting collections
 

--- a/src/io/curl.rs
+++ b/src/io/curl.rs
@@ -1,33 +1,64 @@
 use crate::model::{Auth, HttpMethod, KvRow, Request};
 use crate::net::ensure_url_scheme;
+use crate::privacy;
 use uuid::Uuid;
 
 pub fn to_curl(req: &Request) -> String {
+    to_curl_inner(req, false)
+}
+
+pub fn to_curl_redacted(req: &Request) -> String {
+    to_curl_inner(req, true)
+}
+
+fn to_curl_inner(req: &Request, redact: bool) -> String {
     let mut parts: Vec<String> = Vec::new();
     parts.push("curl".to_string());
     parts.push(format!("-X {}", req.method));
 
     let full_url = build_full_url(&ensure_url_scheme(&req.url), &req.query_params);
+    let full_url = if redact {
+        privacy::redact_url_sensitive_query_values(&full_url)
+    } else {
+        full_url
+    };
     parts.push(format!("'{}'", esc(&full_url)));
 
     for h in &req.headers {
         if !h.enabled || h.key.trim().is_empty() {
             continue;
         }
-        parts.push(format!("-H '{}: {}'", esc(&h.key), esc(&h.value)));
+        let value = if redact {
+            privacy::redact_header_value(&h.key, &h.value)
+        } else {
+            h.value.clone()
+        };
+        parts.push(format!("-H '{}: {}'", esc(&h.key), esc(&value)));
     }
 
     match &req.auth {
         Auth::Bearer { token } if !token.is_empty() => {
+            let token = if redact {
+                privacy::REDACTED_VALUE
+            } else {
+                token
+            };
             parts.push(format!("-H 'Authorization: Bearer {}'", esc(token)));
         }
         Auth::OAuth2(s) if !s.access_token.is_empty() => {
-            parts.push(format!(
-                "-H 'Authorization: Bearer {}'",
-                esc(&s.access_token)
-            ));
+            let token = if redact {
+                privacy::REDACTED_VALUE
+            } else {
+                &s.access_token
+            };
+            parts.push(format!("-H 'Authorization: Bearer {}'", esc(token)));
         }
         Auth::Basic { username, password } if !username.is_empty() => {
+            let password = if redact {
+                privacy::REDACTED_VALUE
+            } else {
+                password
+            };
             parts.push(format!("-u '{}:{}'", esc(username), esc(password)));
         }
         _ => {}
@@ -37,7 +68,14 @@ pub fn to_curl(req: &Request) -> String {
         .cookies
         .iter()
         .filter(|c| c.enabled && !c.key.is_empty())
-        .map(|c| format!("{}={}", c.key, c.value))
+        .map(|c| {
+            let value = if redact {
+                privacy::REDACTED_VALUE
+            } else {
+                &c.value
+            };
+            format!("{}={}", c.key, value)
+        })
         .collect::<Vec<_>>()
         .join("; ");
     if !cookie_str.is_empty() {
@@ -45,7 +83,12 @@ pub fn to_curl(req: &Request) -> String {
     }
 
     if !req.body.is_empty() {
-        parts.push(format!("--data-raw '{}'", esc(&req.body)));
+        let body = if redact {
+            privacy::redact_body_text(&req.body)
+        } else {
+            req.body.clone()
+        };
+        parts.push(format!("--data-raw '{}'", esc(&body)));
     }
 
     parts.join(" \\\n  ")
@@ -639,5 +682,47 @@ mod tests {
         assert!(s.contains("https://a.com?q=1"));
         assert!(s.contains("-H 'X-Foo: bar'"));
         assert!(s.contains("--data-raw '{}'"));
+    }
+
+    #[test]
+    fn to_curl_redacted_preserves_shape_without_secrets() {
+        let r = Request {
+            id: "x".into(),
+            name: "n".into(),
+            description: String::new(),
+            method: HttpMethod::POST,
+            url: "https://a.com/login?token=base-secret".into(),
+            query_params: vec![
+                KvRow::new("page", "1"),
+                KvRow::new("api_key", "query-secret"),
+            ],
+            path_params: Vec::new(),
+            headers: vec![
+                KvRow::new("Authorization", "Bearer header-secret"),
+                KvRow::new("Set-Cookie", "sid=set-secret; Path=/"),
+                KvRow::new("X-Trace", "trace-1"),
+            ],
+            cookies: vec![KvRow::new("sid", "cookie-secret")],
+            body: r#"{"username":"ada","password":"body-secret"}"#.into(),
+            body_ext: None,
+            auth: Auth::Basic {
+                username: "ada".into(),
+                password: "basic-secret".into(),
+            },
+            extractors: vec![],
+            assertions: vec![],
+            source: None,
+        };
+
+        let s = to_curl_redacted(&r);
+        assert!(s.contains("-X POST"));
+        assert!(s.contains("https://a.com/login?token=<redacted>&page=1&api_key=<redacted>"));
+        assert!(s.contains("-H 'Authorization: Bearer <redacted>'"));
+        assert!(s.contains("-H 'Set-Cookie: sid=<redacted>; Path=<redacted>'"));
+        assert!(s.contains("-H 'X-Trace: trace-1'"));
+        assert!(s.contains("-b 'sid=<redacted>'"));
+        assert!(s.contains("-u 'ada:<redacted>'"));
+        assert!(s.contains("\"password\": \"<redacted>\""));
+        assert!(!s.contains("secret"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1743,14 +1743,14 @@ impl ApiClient {
             }
             A::CopyAsCurl => {
                 if let Some(req) = self.get_current_request() {
-                    let s = curl::to_curl(&req);
+                    let s = curl::to_curl_redacted(&req);
                     // egui's Context::copy_text is frame-scoped; show a
                     // toast and use arboard-like behavior via ctx next
                     // frame would be ideal, but render_toast is the
                     // immediate confirmation users expect.
                     // Use egui's clipboard by writing to the context.
                     self.pending_clipboard = Some(s);
-                    self.show_toast("Copied cURL to clipboard");
+                    self.show_toast("Copied redacted cURL to clipboard");
                 }
             }
             A::ToggleSnippetPanel => self.show_snippet_panel = !self.show_snippet_panel,

--- a/src/privacy.rs
+++ b/src/privacy.rs
@@ -1,6 +1,7 @@
 const MASK_SHORT_MAX: usize = 8;
 const MASK_LONG_PREFIX: usize = 6;
 const MASK_LONG_SUFFIX: usize = 4;
+pub const REDACTED_VALUE: &str = "<redacted>";
 
 /// Returns true for common header, cookie, query, and form keys that
 /// usually carry credentials or session material.
@@ -76,6 +77,88 @@ pub fn mask_secret_value(value: &str) -> String {
     format!("{}...{}", prefix, suffix)
 }
 
+/// Redact a value when its key commonly carries credentials.
+pub fn redact_sensitive_value(key: &str, value: &str) -> String {
+    if is_sensitive_key(key) {
+        REDACTED_VALUE.to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+/// Redact request header values while preserving enough protocol shape
+/// to keep generated snippets useful.
+pub fn redact_header_value(key: &str, value: &str) -> String {
+    if !is_sensitive_key(key) {
+        return value.to_string();
+    }
+
+    let normalized = normalize_key(key);
+    if normalized == "authorization" || normalized == "proxyauthorization" {
+        return redact_authorization_value(value);
+    }
+    if normalized == "cookie" || normalized == "setcookie" {
+        return redact_cookie_header_value(value);
+    }
+
+    REDACTED_VALUE.to_string()
+}
+
+/// Redact URL query values whose keys look sensitive and hide fragments.
+pub fn redact_url_sensitive_query_values(url: &str) -> String {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    let (without_fragment, fragment) = match trimmed.split_once('#') {
+        Some((base, frag)) if !frag.is_empty() => (base, Some("#...")),
+        Some((base, _)) => (base, Some("#")),
+        None => (trimmed, None),
+    };
+
+    let mut out = match without_fragment.split_once('?') {
+        Some((base, query)) if !query.is_empty() => {
+            let redacted_query = query
+                .split('&')
+                .map(redact_query_part)
+                .collect::<Vec<_>>()
+                .join("&");
+            format!("{}?{}", base, redacted_query)
+        }
+        Some((base, _)) => format!("{}?", base),
+        None => without_fragment.to_string(),
+    };
+    if let Some(fragment) = fragment {
+        out.push_str(fragment);
+    }
+    out
+}
+
+/// Redact sensitive JSON or form-like body fields. Bodies that do not
+/// expose key/value structure are returned unchanged.
+pub fn redact_body_text(body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    if let Ok(mut value) = serde_json::from_str::<serde_json::Value>(body) {
+        redact_json_value(&mut value, None);
+        return serde_json::to_string_pretty(&value).unwrap_or_else(|_| body.to_string());
+    }
+
+    if looks_like_form_body(body) {
+        return body
+            .split('&')
+            .map(redact_query_part)
+            .collect::<Vec<_>>()
+            .join("&");
+    }
+
+    body.to_string()
+}
+
 /// Escape text for safe insertion into HTML text/attribute contexts.
 pub fn escape_html(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
@@ -97,6 +180,76 @@ fn normalize_key(key: &str) -> String {
         .filter(|c| c.is_ascii_alphanumeric())
         .flat_map(|c| c.to_lowercase())
         .collect()
+}
+
+fn redact_authorization_value(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    match trimmed.split_once(char::is_whitespace) {
+        Some((scheme, _)) if !scheme.is_empty() => format!("{} {}", scheme, REDACTED_VALUE),
+        _ => REDACTED_VALUE.to_string(),
+    }
+}
+
+fn redact_cookie_header_value(value: &str) -> String {
+    value
+        .split(';')
+        .map(|part| {
+            let trimmed = part.trim();
+            if trimmed.is_empty() {
+                return String::new();
+            }
+            match trimmed.split_once('=') {
+                Some((name, _)) if !name.trim().is_empty() => {
+                    format!("{}={}", name.trim(), REDACTED_VALUE)
+                }
+                _ => REDACTED_VALUE.to_string(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn redact_query_part(part: &str) -> String {
+    match part.split_once('=') {
+        Some((key, value)) => {
+            let redacted = redact_sensitive_value(key, value);
+            format!("{}={}", key, redacted)
+        }
+        None if is_sensitive_key(part) => format!("{}={}", part, REDACTED_VALUE),
+        None => part.to_string(),
+    }
+}
+
+fn looks_like_form_body(body: &str) -> bool {
+    body.split('&').any(|part| {
+        part.split_once('=')
+            .map(|(key, _)| is_sensitive_key(key))
+            .unwrap_or(false)
+    })
+}
+
+fn redact_json_value(value: &mut serde_json::Value, parent_key: Option<&str>) {
+    if parent_key.is_some_and(is_sensitive_key) {
+        *value = serde_json::Value::String(REDACTED_VALUE.to_string());
+        return;
+    }
+
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, child) in map {
+                redact_json_value(child, Some(key));
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for child in items {
+                redact_json_value(child, None);
+            }
+        }
+        _ => {}
+    }
 }
 
 #[cfg(test)]
@@ -132,6 +285,40 @@ mod tests {
         assert_eq!(
             redact_url_query_and_fragment(url),
             "https://api.example.com/users?..."
+        );
+    }
+
+    #[test]
+    fn url_sensitive_redaction_preserves_non_secret_query_values() {
+        let url = "https://api.example.com/users?page=2&api_key=secret#access_token=secret";
+        assert_eq!(
+            redact_url_sensitive_query_values(url),
+            "https://api.example.com/users?page=2&api_key=<redacted>#..."
+        );
+    }
+
+    #[test]
+    fn header_redaction_preserves_auth_and_cookie_shape() {
+        assert_eq!(
+            redact_header_value("Authorization", "Bearer abc123"),
+            "Bearer <redacted>"
+        );
+        assert_eq!(
+            redact_header_value("Cookie", "sid=abc; theme=dark"),
+            "sid=<redacted>; theme=<redacted>"
+        );
+        assert_eq!(redact_header_value("X-Trace", "abc123"), "abc123");
+    }
+
+    #[test]
+    fn body_redaction_handles_json_and_form_keys() {
+        assert_eq!(
+            redact_body_text(r#"{"user":"ada","password":"secret","nested":{"token":"abc"}}"#),
+            "{\n  \"nested\": {\n    \"token\": \"<redacted>\"\n  },\n  \"password\": \"<redacted>\",\n  \"user\": \"ada\"\n}"
+        );
+        assert_eq!(
+            redact_body_text("username=ada&access_token=abc"),
+            "username=ada&access_token=<redacted>"
         );
     }
 

--- a/src/snippet.rs
+++ b/src/snippet.rs
@@ -470,41 +470,77 @@ impl SnippetLang {
 }
 
 pub fn render_snippet(req: &Request, lang: SnippetLang) -> String {
+    render_snippet_inner(req, lang, false)
+}
+
+pub fn render_snippet_redacted(req: &Request, lang: SnippetLang) -> String {
+    render_snippet_inner(req, lang, true)
+}
+
+fn render_snippet_inner(req: &Request, lang: SnippetLang, redact: bool) -> String {
     match lang {
-        SnippetLang::Curl => curl::to_curl(req),
-        SnippetLang::Python => python(req),
-        SnippetLang::JavaScript => javascript(req),
-        SnippetLang::HttpieShell => httpie(req),
+        SnippetLang::Curl => {
+            if redact {
+                curl::to_curl_redacted(req)
+            } else {
+                curl::to_curl(req)
+            }
+        }
+        SnippetLang::Python => python(req, redact),
+        SnippetLang::JavaScript => javascript(req, redact),
+        SnippetLang::HttpieShell => httpie(req, redact),
     }
 }
 
-fn collect_send_headers(req: &Request) -> Vec<(String, String)> {
+fn collect_send_headers(req: &Request, redact: bool) -> Vec<(String, String)> {
     let mut out: Vec<(String, String)> = req
         .headers
         .iter()
         .filter(|h| h.enabled && !h.key.trim().is_empty())
-        .map(|h| (h.key.clone(), h.value.clone()))
+        .map(|h| {
+            let value = if redact {
+                crate::privacy::redact_header_value(&h.key, &h.value)
+            } else {
+                h.value.clone()
+            };
+            (h.key.clone(), value)
+        })
         .collect();
     if let Auth::Bearer { token } = &req.auth {
         if !token.is_empty() {
+            let token = if redact {
+                crate::privacy::REDACTED_VALUE
+            } else {
+                token
+            };
             out.push(("Authorization".into(), format!("Bearer {}", token)));
         }
     }
     // OAuth2 → Bearer <access_token>, mirroring the send path.
     if let Auth::OAuth2(s) = &req.auth {
         if !s.access_token.is_empty() {
-            out.push(("Authorization".into(), format!("Bearer {}", s.access_token)));
+            let token = if redact {
+                crate::privacy::REDACTED_VALUE
+            } else {
+                &s.access_token
+            };
+            out.push(("Authorization".into(), format!("Bearer {}", token)));
         }
     }
     out
 }
 
-fn python(req: &Request) -> String {
+fn python(req: &Request, redact: bool) -> String {
     let mut s = String::new();
     s.push_str("import requests\n\n");
     let url = curl::build_full_url(&crate::net::ensure_url_scheme(&req.url), &req.query_params);
+    let url = if redact {
+        crate::privacy::redact_url_sensitive_query_values(&url)
+    } else {
+        url
+    };
     s.push_str(&format!("url = {:?}\n", url));
-    let headers = collect_send_headers(req);
+    let headers = collect_send_headers(req, redact);
     if !headers.is_empty() {
         s.push_str("headers = {\n");
         for (k, v) in &headers {
@@ -514,11 +550,18 @@ fn python(req: &Request) -> String {
     } else {
         s.push_str("headers = {}\n");
     }
-    let cookies: Vec<(&String, &String)> = req
+    let cookies: Vec<(&String, &str)> = req
         .cookies
         .iter()
         .filter(|c| c.enabled && !c.key.is_empty())
-        .map(|c| (&c.key, &c.value))
+        .map(|c| {
+            let value = if redact {
+                crate::privacy::REDACTED_VALUE
+            } else {
+                c.value.as_str()
+            };
+            (&c.key, value)
+        })
         .collect();
     if !cookies.is_empty() {
         s.push_str("cookies = {\n");
@@ -530,6 +573,11 @@ fn python(req: &Request) -> String {
     let mut auth_arg = String::new();
     if let Auth::Basic { username, password } = &req.auth {
         if !username.is_empty() {
+            let password = if redact {
+                crate::privacy::REDACTED_VALUE
+            } else {
+                password
+            };
             auth_arg = format!(", auth=({:?}, {:?})", username, password);
         }
     }
@@ -540,7 +588,12 @@ fn python(req: &Request) -> String {
     };
     let method = format!("{}", req.method).to_lowercase();
     if !req.body.is_empty() {
-        s.push_str(&format!("payload = {:?}\n\n", req.body));
+        let body = if redact {
+            crate::privacy::redact_body_text(&req.body)
+        } else {
+            req.body.clone()
+        };
+        s.push_str(&format!("payload = {:?}\n\n", body));
         s.push_str(&format!(
             "response = requests.{}(url, headers=headers{}{}, data=payload)\n",
             method, cookies_arg, auth_arg
@@ -555,18 +608,30 @@ fn python(req: &Request) -> String {
     s
 }
 
-fn javascript(req: &Request) -> String {
+fn javascript(req: &Request, redact: bool) -> String {
     let mut s = String::new();
     let url = curl::build_full_url(&crate::net::ensure_url_scheme(&req.url), &req.query_params);
+    let url = if redact {
+        crate::privacy::redact_url_sensitive_query_values(&url)
+    } else {
+        url
+    };
     s.push_str(&format!("const url = {:?};\n\n", url));
     s.push_str("const options = {\n");
     s.push_str(&format!("  method: {:?},\n", req.method.to_string()));
-    let headers = collect_send_headers(req);
+    let headers = collect_send_headers(req, redact);
     let cookies: Vec<String> = req
         .cookies
         .iter()
         .filter(|c| c.enabled && !c.key.is_empty())
-        .map(|c| format!("{}={}", c.key, c.value))
+        .map(|c| {
+            let value = if redact {
+                crate::privacy::REDACTED_VALUE
+            } else {
+                &c.value
+            };
+            format!("{}={}", c.key, value)
+        })
         .collect();
     let mut header_lines: Vec<String> = headers
         .iter()
@@ -581,7 +646,12 @@ fn javascript(req: &Request) -> String {
         s.push_str(",\n  },\n");
     }
     if !req.body.is_empty() {
-        s.push_str(&format!("  body: {:?},\n", req.body));
+        let body = if redact {
+            crate::privacy::redact_body_text(&req.body)
+        } else {
+            req.body.clone()
+        };
+        s.push_str(&format!("  body: {:?},\n", body));
     }
     s.push_str("};\n\n");
     s.push_str("fetch(url, options)\n");
@@ -591,15 +661,25 @@ fn javascript(req: &Request) -> String {
     s
 }
 
-fn httpie(req: &Request) -> String {
+fn httpie(req: &Request, redact: bool) -> String {
     let mut parts: Vec<String> = vec!["http".into(), format!("{}", req.method)];
     let url = curl::build_full_url(&crate::net::ensure_url_scheme(&req.url), &req.query_params);
+    let url = if redact {
+        crate::privacy::redact_url_sensitive_query_values(&url)
+    } else {
+        url
+    };
     parts.push(format!("'{}'", url.replace('\'', "'\\''")));
-    for (k, v) in collect_send_headers(req) {
+    for (k, v) in collect_send_headers(req, redact) {
         parts.push(format!("'{}:{}'", k, v));
     }
     if let Auth::Basic { username, password } = &req.auth {
         if !username.is_empty() {
+            let password = if redact {
+                crate::privacy::REDACTED_VALUE
+            } else {
+                password
+            };
             parts.push(format!("--auth='{}:{}'", username, password));
         }
     }
@@ -607,17 +687,112 @@ fn httpie(req: &Request) -> String {
         .cookies
         .iter()
         .filter(|c| c.enabled && !c.key.is_empty())
-        .map(|c| format!("{}={}", c.key, c.value))
+        .map(|c| {
+            let value = if redact {
+                crate::privacy::REDACTED_VALUE
+            } else {
+                &c.value
+            };
+            format!("{}={}", c.key, value)
+        })
         .collect();
     if !cookies.is_empty() {
         parts.push(format!("'Cookie:{}'", cookies.join("; ")));
     }
     let mut s = parts.join(" ");
     if !req.body.is_empty() {
+        let body = if redact {
+            crate::privacy::redact_body_text(&req.body)
+        } else {
+            req.body.clone()
+        };
         s.push_str(&format!(
             "\n# body (use --raw or pipe stdin):\n# echo {:?} | http ...",
-            req.body
+            body
         ));
     }
     s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Auth, HttpMethod, KvRow, Request};
+
+    fn secret_request() -> Request {
+        Request {
+            id: "x".into(),
+            name: "n".into(),
+            description: String::new(),
+            method: HttpMethod::POST,
+            url: "https://api.example.com/login".into(),
+            query_params: vec![
+                KvRow::new("page", "1"),
+                KvRow::new("access_token", "query-secret"),
+            ],
+            path_params: vec![],
+            headers: vec![
+                KvRow::new("Content-Type", "application/json"),
+                KvRow::new("Authorization", "Bearer header-secret"),
+                KvRow::new("X-Api-Key", "header-key-secret"),
+            ],
+            cookies: vec![KvRow::new("sid", "cookie-secret")],
+            body: r#"{"username":"ada","password":"body-secret"}"#.into(),
+            body_ext: None,
+            auth: Auth::Basic {
+                username: "ada".into(),
+                password: "basic-secret".into(),
+            },
+            extractors: vec![],
+            assertions: vec![],
+            source: None,
+        }
+    }
+
+    #[test]
+    fn redacts_curl_snippet() {
+        let s = render_snippet_redacted(&secret_request(), SnippetLang::Curl);
+        assert!(s.contains("access_token=<redacted>"));
+        assert!(s.contains("-H 'Authorization: Bearer <redacted>'"));
+        assert!(s.contains("-H 'X-Api-Key: <redacted>'"));
+        assert!(s.contains("-b 'sid=<redacted>'"));
+        assert!(s.contains("-u 'ada:<redacted>'"));
+        assert!(s.contains("\"password\": \"<redacted>\""));
+        assert!(!s.contains("secret"));
+    }
+
+    #[test]
+    fn redacts_python_snippet() {
+        let s = render_snippet_redacted(&secret_request(), SnippetLang::Python);
+        assert!(s.contains("access_token=<redacted>"));
+        assert!(s.contains("\"Authorization\": \"Bearer <redacted>\""));
+        assert!(s.contains("\"X-Api-Key\": \"<redacted>\""));
+        assert!(s.contains("\"sid\": \"<redacted>\""));
+        assert!(s.contains("auth=(\"ada\", \"<redacted>\")"));
+        assert!(s.contains("\\\"password\\\": \\\"<redacted>\\\""));
+        assert!(!s.contains("secret"));
+    }
+
+    #[test]
+    fn redacts_javascript_fetch_snippet() {
+        let s = render_snippet_redacted(&secret_request(), SnippetLang::JavaScript);
+        assert!(s.contains("access_token=<redacted>"));
+        assert!(s.contains("\"Authorization\": \"Bearer <redacted>\""));
+        assert!(s.contains("\"X-Api-Key\": \"<redacted>\""));
+        assert!(s.contains("\"Cookie\": \"sid=<redacted>\""));
+        assert!(s.contains("\\\"password\\\": \\\"<redacted>\\\""));
+        assert!(!s.contains("secret"));
+    }
+
+    #[test]
+    fn redacts_httpie_snippet() {
+        let s = render_snippet_redacted(&secret_request(), SnippetLang::HttpieShell);
+        assert!(s.contains("access_token=<redacted>"));
+        assert!(s.contains("'Authorization:Bearer <redacted>'"));
+        assert!(s.contains("'X-Api-Key:<redacted>'"));
+        assert!(s.contains("'Cookie:sid=<redacted>'"));
+        assert!(s.contains("--auth='ada:<redacted>'"));
+        assert!(s.contains("\\\"password\\\": \\\"<redacted>\\\""));
+        assert!(!s.contains("secret"));
+    }
 }

--- a/src/ui/modals.rs
+++ b/src/ui/modals.rs
@@ -6,7 +6,9 @@
 
 use crate::io::curl;
 use crate::model::*;
-use crate::snippet::{build_snippet_layout_job_content_only, render_snippet, SnippetLang};
+use crate::snippet::{
+    build_snippet_layout_job_content_only, render_snippet, render_snippet_redacted, SnippetLang,
+};
 use crate::theme::*;
 use crate::widgets::*;
 use crate::{
@@ -830,8 +832,10 @@ impl ApiClient {
                 return;
             }
         };
-        let snippet = render_snippet(&req, self.snippet_lang);
+        let snippet = render_snippet_redacted(&req, self.snippet_lang);
+        let raw_snippet = render_snippet(&req, self.snippet_lang);
         let mut copy_clicked = false;
+        let mut copy_raw_clicked = false;
         let mut close_clicked = false;
 
         egui::SidePanel::right("snippet_panel")
@@ -873,8 +877,17 @@ impl ApiClient {
                             }
                         });
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        if icon_btn(ui, egui_phosphor::regular::COPY, "Copy snippet").clicked() {
+                        if icon_btn(ui, egui_phosphor::regular::COPY, "Copy redacted snippet")
+                            .clicked()
+                        {
                             copy_clicked = true;
+                        }
+                        if ui
+                            .button("Copy raw")
+                            .on_hover_text("Copy snippet with original values")
+                            .clicked()
+                        {
+                            copy_raw_clicked = true;
                         }
                         // "Copied!" flash sits to the LEFT of the button
                         // (layout is right-to-left). Visible for ~1.5s
@@ -968,6 +981,10 @@ impl ApiClient {
 
         if copy_clicked {
             ctx.output_mut(|o| o.copied_text = snippet);
+            self.snippet_copied_at = Some(ctx.input(|i| i.time));
+        }
+        if copy_raw_clicked {
+            ctx.output_mut(|o| o.copied_text = raw_snippet);
             self.snippet_copied_at = Some(ctx.input(|i| i.time));
         }
         if close_clicked {


### PR DESCRIPTION
## Summary
- add shared redaction helpers for URLs, headers, cookies, and sensitive body fields
- add redacted cURL and language snippet generation while preserving request shape
- make snippet copy safer by default with explicit raw-copy affordances
- document safe snippet/cURL sharing

## Tests
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features -- -D warnings

Closes #41
