### PR TITLE
Add collection-level Git sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Added
+- **Collection-level Git sync settings.** Top-level collections now have a
+  Collection Settings entry with a local collection directory, Git remote
+  pull/push actions, a compact Git status/diff summary, and collection-scoped
+  OpenAPI refresh. Private Git remotes use the user's existing local Git
+  credentials; Rusty Requester stores no GitHub tokens.
+- **Reviewable `.rr` request files.** Git workspace exports now write each
+  request as pretty JSON with a Rusty Requester `.rr` extension while still
+  importing older `.json` request files.
+
 ## [0.25.0] — 2026-06-17
 
 ### Added

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -151,16 +151,21 @@ the original values.
 - **Right-click any collection / folder → Export as JSON / YAML…** — exports just that subtree (this is the "collection-level" export for sharing).
 - Before collection export, Rusty Requester runs a local-only secret scan for common API keys, bearer/JWT-style tokens, OAuth/basic auth secrets, cookies, and sensitive key names such as `Authorization`, `token`, `password`, `client_secret`, and `api_key`. If likely secrets are found, you can cancel, continue with the original export, or export a redacted copy with likely secret values replaced by `[REDACTED]`. This scanner never uploads export content. It is heuristic: unusual secret formats may be missed, and placeholder or example values may still produce false positives.
 - **Git workspace format** — core import/export code can write a deterministic
-  directory with `workspace.json` plus one readable JSON file per request. It
-  preserves IDs for Git round-trips and masks secrets by default. See
+  directory with `workspace.json` plus one readable `.rr` request file per
+  request. `.rr` files contain pretty JSON, preserve IDs for Git round-trips,
+  and mask secrets by default. See
   [`GIT_WORKSPACE_FORMAT.md`](./GIT_WORKSPACE_FORMAT.md) for layout and
   merge-conflict expectations.
+- **Collection-level Git UI** — each top-level collection can point at its own
+  local Git repository from **Collection settings...**. The free Git panel can
+  show status/diff summary, pull from remote, export the collection, commit,
+  and push through your existing local Git credentials.
 - **Workspace Sync** — optional, off by default in Settings. When enabled,
   **Workspace Sync…** lets you pull from a Git workspace directory, push a
-  masked Git workspace snapshot, pull/push a GitHub or other Git remote through
-  your local Git credentials, and refresh OpenAPI-generated requests from a
-  local JSON/YAML spec. Private repos work through your SSH key or Git
-  credential helper; Rusty Requester stores no GitHub token.
+  masked Git workspace snapshot, pull/push a Git remote through your local Git
+  credentials, and refresh OpenAPI-generated requests from a local JSON/YAML
+  spec. Private repos work through your SSH key or Git credential helper; Rusty
+  Requester stores no GitHub token.
 
 ### Running collections with data rows
 
@@ -359,4 +364,4 @@ _Nothing open — OAuth 2.0 Auth Code + PKCE *(v0.15)* was the last v1.0 item._
 - [ ] **Pre-request scripts** — Rhai/Boa scripting engine for transformations before send.
 - [ ] **Windows builds** — CI + installer parity with macOS/Linux.
 - [x] **OpenAPI import / refresh** — import a spec into collections and refresh existing generated requests.
-- [x] **Git-backed workspace sync** — optional local-file and GitHub/local Git mode for teams that want normal Git review / merge flow.
+- [x] **Git-backed workspace sync** — optional collection-level and whole-workspace local Git mode for teams that want normal Git review / merge flow.

--- a/docs/GIT_WORKSPACE_FORMAT.md
+++ b/docs/GIT_WORKSPACE_FORMAT.md
@@ -11,15 +11,19 @@ Git workspace imports preserve IDs so branches can round-trip cleanly.
 workspace.json
 requests/
   001-collection-name-collection-id/
-    001-request-name-request-id.json
-    002-other-request-other-request-id.json
+    001-request-name-request-id.rr
+    002-other-request-other-request-id.rr
     001-nested-folder-folder-id/
-      001-nested-request-request-id.json
+      001-nested-request-request-id.rr
 ```
 
 - `workspace.json` is the manifest. It records the format name, version, secret
   policy, ordered folder tree, and each request file path.
-- Each request lives in its own readable JSON file under `requests/`.
+- Each request lives in its own readable `.rr` file under `requests/`. The
+  contents are still pretty JSON, so diffs stay readable in GitHub, GitLab,
+  Bitbucket, terminals, and normal editors.
+- Imports remain backward-compatible with older workspaces whose manifest
+  points at `.json` request files.
 - Folder and request file names include a 1-based order prefix, a readable slug,
   and the stable object ID. The manifest is the source of truth for order.
 - Export rewrites the managed `requests/` directory so stale request files do
@@ -58,7 +62,7 @@ in the files, including masked placeholders.
 Expected conflict shape:
 
 - Two people edit different request files: Git usually merges cleanly.
-- Two people edit the same request file: resolve the JSON object like any other
+- Two people edit the same request file: resolve the `.rr` JSON object like any other
   small source file, keeping the original `id`.
 - Two people reorder or move requests: resolve `workspace.json` first because it
   owns ordering and file paths.
@@ -68,4 +72,5 @@ Expected conflict shape:
   after resolving conflicts if you want to normalize paths and ordering.
 
 The safest manual resolution rule is: preserve IDs, keep one manifest entry per
-request, and make every manifest `path` point to a JSON file with the same `id`.
+request, and make every manifest `path` point to a `.rr` or legacy `.json` file
+with the same `id`.

--- a/docs/index.html
+++ b/docs/index.html
@@ -355,8 +355,8 @@ footer a:hover { color: var(--accent); }
         <p>Redacted cURL and code snippets preserve request shape while masking obvious auth, cookie, query, and body secrets. Raw copy stays explicit.</p>
       </div>
       <div class="feat">
-        <h3>Opt-in workspace sync</h3>
-        <p>Enable GitHub/local Git workspace pull-push and OpenAPI refresh when you need reviewable team workflows. Private repos use your local Git credentials.</p>
+        <h3>Collection Git sync</h3>
+        <p>Link a collection to a Git repo, review readable .rr request files, inspect status/diff, pull, commit, and push through local Git credentials. Private repos work without storing provider tokens.</p>
       </div>
     </div>
   </div>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -593,25 +593,26 @@ bob,secret2,staging-b</code></pre>
         </div>
       </div>
       <h3>OpenAPI refresh</h3>
-      <p>Generated OpenAPI metadata lets the app refresh imported requests from an updated spec while preserving user-edited names, auth values, tests, and extractors where possible. Enable <strong>Workspace Sync</strong> in Settings, open <strong>Workspace Sync…</strong>, choose a local OpenAPI JSON/YAML file, then click <strong>Refresh from OpenAPI spec</strong>.</p>
+      <p>Generated OpenAPI metadata lets the app refresh imported requests from an updated spec while preserving user-edited names, auth values, tests, and extractors where possible. For collection-scoped refresh, open a collection's <strong>Collection settings...</strong>, choose a local OpenAPI JSON/YAML file, then click <strong>Refresh collection from OpenAPI</strong>.</p>
     </section>
 
     <section id="git-workspace">
-      <h2>Git Workspace Sync</h2>
-      <p>Workspace Sync is optional and off by default. Enable it in Settings to pull from or push to a local Git workspace directory, then use your normal GitHub repository as the remote. Private repos work through your local SSH key or Git credential helper; Rusty Requester does not store GitHub tokens. The app writes a deterministic directory instead of one giant export file.</p>
+      <h2>Collection Git Sync</h2>
+      <p>Each top-level collection can be linked to its own local folder or Git repository. Open the collection menu, choose <strong>Collection settings...</strong>, select a repository root, then use <strong>Export to folder</strong>, <strong>Refresh changes</strong>, <strong>Pull from remote</strong>, or <strong>Commit and push</strong>. Private GitHub/GitLab/Bitbucket repos work through your local SSH key or Git credential helper; Rusty Requester does not sign in to Git providers or store GitHub tokens.</p>
       <pre><code>workspace.json
 requests/
   001-my-api-collection-id/
-    001-login-request-id.json
+    001-login-request-id.rr
     001-users-folder-id/
-      001-list-users-request-id.json</code></pre>
+      001-list-users-request-id.rr</code></pre>
       <ul>
-        <li>One readable JSON file per request.</li>
+        <li>One readable <code>.rr</code> file per request, containing pretty JSON.</li>
         <li>Stable IDs for round trips.</li>
         <li>Deterministic ordering for cleaner diffs.</li>
         <li>Secret masking by default for safer commits.</li>
-        <li>Manual GitHub/local Git actions: pull, export + commit, and push.</li>
+        <li>Free Git UI: status/diff summary, pull, export, commit, and push.</li>
       </ul>
+      <p>The older <strong>Workspace Sync...</strong> modal is still available for whole-workspace import/export, but collection settings are the recommended path for team Git review.</p>
       <p>Full format reference: <a href="./GIT_WORKSPACE_FORMAT.md">GIT_WORKSPACE_FORMAT.md</a>.</p>
     </section>
 

--- a/readme.md
+++ b/readme.md
@@ -78,7 +78,8 @@ views, **Server-Sent Events streaming** for LLM APIs, **Cancel**
 mid-flight, **Response diff** across sends, **Collection Runner** with
 CSV/JSON data rows, presets, detail drilldowns, scoped runs, safe
 CSV/HTML reports, redacted code snippets, Git-friendly workspace
-exports, opt-in Workspace Sync for GitHub/local Git pull-push and
+exports, collection-level Git sync with readable `.rr` request files,
+status/diff review, pull/commit/push through your local Git credentials,
 OpenAPI refresh, request finder + actions palette (`Cmd` on macOS,
 `Ctrl` on Linux/Windows), and platform menus. Full catalog in
 [`docs/FEATURES.md`](docs/FEATURES.md) and the usage guide in

--- a/src/io/git_workspace.rs
+++ b/src/io/git_workspace.rs
@@ -12,6 +12,7 @@ const FORMAT_NAME: &str = "rusty-requester-git-workspace";
 const FORMAT_VERSION: u32 = 1;
 const MANIFEST_FILE: &str = "workspace.json";
 const REQUESTS_DIR: &str = "requests";
+const REQUEST_FILE_EXTENSION: &str = "rr";
 const MAX_REQUEST_FILES: usize = 5_000;
 const MAX_FOLDER_DEPTH: usize = 32;
 const MAX_IMPORT_BYTES: u64 = 50 * 1024 * 1024;
@@ -201,8 +202,9 @@ fn manifest_folder(
             request_path.push(component);
         }
         request_path.push(format!(
-            "{}.json",
-            path_component(request_index, &request.name, &request.id, "request")
+            "{}.{}",
+            path_component(request_index, &request.name, &request.id, "request"),
+            REQUEST_FILE_EXTENSION
         ));
 
         requests.push(ManifestRequest {
@@ -280,6 +282,7 @@ fn import_manifest_folders(
             requests,
             subfolders: import_manifest_folders(root, &folder.subfolders, budget, depth + 1)?,
             description: folder.description.clone(),
+            sync: crate::model::SyncConfig::default(),
         });
     }
     Ok(out)
@@ -325,9 +328,10 @@ fn validate_manifest_path(path: &str) -> Result<PathBuf, String> {
     if relative.is_absolute() {
         return Err(format!("Workspace request path must be relative: {}", path));
     }
-    if relative.extension() != Some(OsStr::new("json")) {
+    let ext = relative.extension();
+    if ext != Some(OsStr::new(REQUEST_FILE_EXTENSION)) && ext != Some(OsStr::new("json")) {
         return Err(format!(
-            "Workspace request path must be a JSON file: {}",
+            "Workspace request path must be a .rr or .json file: {}",
             path
         ));
     }
@@ -521,6 +525,7 @@ mod tests {
                 id: "collection-1-sub".into(),
                 name: "Nested".into(),
                 description: String::new(),
+                sync: crate::model::SyncConfig::default(),
                 requests: vec![Request {
                     id: "request-2".into(),
                     name: "Status".into(),
@@ -552,6 +557,7 @@ mod tests {
                 }],
                 subfolders: vec![],
             }],
+            sync: crate::model::SyncConfig::default(),
         }]
     }
 
@@ -585,18 +591,18 @@ mod tests {
         assert_eq!(summary.manifest_path, root.join(MANIFEST_FILE));
         assert!(root.join(MANIFEST_FILE).is_file());
         assert!(root
-            .join("requests/001-fixture-api-collection-1/001-create-widget-request-1.json")
+            .join("requests/001-fixture-api-collection-1/001-create-widget-request-1.rr")
             .is_file());
         assert!(root
             .join(
-                "requests/001-fixture-api-collection-1/001-nested-collection-1-sub/001-status-request-2.json"
+                "requests/001-fixture-api-collection-1/001-nested-collection-1-sub/001-status-request-2.rr"
             )
             .is_file());
 
         let manifest = read(root.join(MANIFEST_FILE));
         assert!(manifest.contains("\"format\": \"rusty-requester-git-workspace\""));
         assert!(manifest.contains(
-            "\"path\": \"requests/001-fixture-api-collection-1/001-create-widget-request-1.json\""
+            "\"path\": \"requests/001-fixture-api-collection-1/001-create-widget-request-1.rr\""
         ));
 
         let first_manifest = manifest.clone();
@@ -610,9 +616,8 @@ mod tests {
         let root = temp_workspace("mask");
         export_workspace_to_dir(&fixture_folders(), &root, ExportOptions::default()).unwrap();
 
-        let first_request = read(
-            root.join("requests/001-fixture-api-collection-1/001-create-widget-request-1.json"),
-        );
+        let first_request =
+            read(root.join("requests/001-fixture-api-collection-1/001-create-widget-request-1.rr"));
         assert!(!first_request.contains("query-secret"));
         assert!(!first_request.contains("header-secret"));
         assert!(!first_request.contains("cookie-secret"));
@@ -622,7 +627,7 @@ mod tests {
         assert!(first_request.contains("https://api.example.com/widgets?...#..."));
 
         let second_request = read(root.join(
-            "requests/001-fixture-api-collection-1/001-nested-collection-1-sub/001-status-request-2.json",
+            "requests/001-fixture-api-collection-1/001-nested-collection-1-sub/001-status-request-2.rr",
         ));
         assert!(!second_request.contains("oauth-client-secret"));
         assert!(!second_request.contains("oauth-access-token"));
@@ -649,6 +654,37 @@ mod tests {
         assert_eq!(imported[0].id, "collection-1");
         assert_eq!(imported[0].requests[0].id, "request-1");
         assert_eq!(imported[0].subfolders[0].requests[0].id, "request-2");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn import_accepts_legacy_json_request_files() {
+        let root = temp_workspace("legacy-json");
+        export_workspace_to_dir(
+            &fixture_folders(),
+            &root,
+            ExportOptions {
+                secret_policy: SecretPolicy::Include,
+            },
+        )
+        .unwrap();
+
+        let rr_path =
+            root.join("requests/001-fixture-api-collection-1/001-create-widget-request-1.rr");
+        let json_path =
+            root.join("requests/001-fixture-api-collection-1/001-create-widget-request-1.json");
+        fs::rename(&rr_path, &json_path).unwrap();
+
+        let manifest_path = root.join(MANIFEST_FILE);
+        let mut manifest: serde_json::Value = serde_json::from_str(&read(&manifest_path)).unwrap();
+        manifest["folders"][0]["requests"][0]["path"] = serde_json::json!(
+            "requests/001-fixture-api-collection-1/001-create-widget-request-1.json"
+        );
+        write_json_file(&manifest_path, &manifest).unwrap();
+
+        let imported = import_workspace_from_dir(&root).unwrap();
+
+        assert_eq!(imported[0].requests[0].id, "request-1");
         let _ = fs::remove_dir_all(root);
     }
 
@@ -683,7 +719,7 @@ mod tests {
         .unwrap();
 
         let path =
-            root.join("requests/001-fixture-api-collection-1/001-create-widget-request-1.json");
+            root.join("requests/001-fixture-api-collection-1/001-create-widget-request-1.rr");
         let mut request: Request = serde_json::from_str(&read(&path)).unwrap();
         request.id = "different".into();
         write_json_file(&path, &request).unwrap();
@@ -700,7 +736,7 @@ mod tests {
 
         let manifest_path = root.join(MANIFEST_FILE);
         let mut manifest: serde_json::Value = serde_json::from_str(&read(&manifest_path)).unwrap();
-        manifest["folders"][0]["requests"][0]["path"] = serde_json::json!("../outside.json");
+        manifest["folders"][0]["requests"][0]["path"] = serde_json::json!("../outside.rr");
         write_json_file(&manifest_path, &manifest).unwrap();
 
         let err = import_workspace_from_dir(&root).unwrap_err();

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,7 +1,9 @@
 pub mod curl;
 pub mod git_workspace;
 
-use crate::model::{Auth, Folder, HttpMethod, KvRow, OpenApiSource, Request, RequestSource};
+use crate::model::{
+    Auth, Folder, HttpMethod, KvRow, OpenApiSource, Request, RequestSource, SyncConfig,
+};
 use crate::privacy::is_sensitive_key;
 use crate::secret_scanner;
 use serde::{Deserialize, Serialize};
@@ -235,6 +237,7 @@ fn folder_by_name_mut<'a>(folders: &'a mut Vec<Folder>, name: &str) -> &'a mut F
         requests: Vec::new(),
         subfolders: Vec::new(),
         description: String::new(),
+        sync: SyncConfig::default(),
     });
     folders.last_mut().expect("folder was just pushed")
 }
@@ -850,6 +853,7 @@ fn postman_to_folder(pc: &PostmanCollection) -> Folder {
         requests: Vec::new(),
         subfolders: Vec::new(),
         description: String::new(),
+        sync: SyncConfig::default(),
     };
     for item in &pc.item {
         process_item(item, &mut root);
@@ -869,6 +873,7 @@ fn process_item(item: &PostmanItem, parent: &mut Folder) {
             requests: Vec::new(),
             subfolders: Vec::new(),
             description: String::new(),
+            sync: SyncConfig::default(),
         };
         for s in subitems {
             process_item(s, &mut sub);
@@ -1087,8 +1092,10 @@ mod tests {
                 }],
                 subfolders: vec![],
                 description: "nested folder fixture".into(),
+                sync: SyncConfig::default(),
             }],
             description: "top-level collection fixture".into(),
+            sync: SyncConfig::default(),
         }]
     }
 
@@ -1151,6 +1158,7 @@ mod tests {
             }],
             subfolders: vec![],
             description: String::new(),
+            sync: SyncConfig::default(),
         }];
         let s = export_string(&folders, Format::Json).unwrap();
         let back = import_from_str(&s, "json").unwrap();
@@ -1168,6 +1176,7 @@ mod tests {
             requests: vec![],
             subfolders: vec![],
             description: String::new(),
+            sync: SyncConfig::default(),
         }];
         let s = export_string(&folders, Format::Yaml).unwrap();
         let back = import_from_str(&s, "yaml").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,9 @@ struct ApiClient {
     show_runner_modal: bool,
     show_backup_modal: bool,
     show_sync_modal: bool,
+    show_collection_settings_modal: bool,
+    collection_settings_folder_id: Option<String>,
+    collection_git_status: String,
     confirm_restore_backup_path: Option<PathBuf>,
     runner_scope_folder_id: Option<String>,
     runner_data_rows: String,
@@ -488,6 +491,9 @@ impl Default for ApiClient {
             show_runner_modal: false,
             show_backup_modal: false,
             show_sync_modal: false,
+            show_collection_settings_modal: false,
+            collection_settings_folder_id: None,
+            collection_git_status: String::new(),
             confirm_restore_backup_path: None,
             runner_scope_folder_id: None,
             runner_data_rows: String::new(),
@@ -629,6 +635,7 @@ impl ApiClient {
                 requests: vec![],
                 subfolders: vec![],
                 description: String::new(),
+                sync: SyncConfig::default(),
             }],
             environments: vec![],
             active_env_id: None,
@@ -1876,6 +1883,16 @@ impl ApiClient {
         }
     }
 
+    pub(crate) fn open_collection_settings(&mut self, folder_id: &str) {
+        if crate::find_folder_by_id(&self.state.folders, folder_id).is_none() {
+            self.show_toast("Collection not found");
+            return;
+        }
+        self.collection_settings_folder_id = Some(folder_id.to_string());
+        self.collection_git_status.clear();
+        self.show_collection_settings_modal = true;
+    }
+
     fn rename_request(&mut self, request_id: &str, new_name: String) {
         fn go(folders: &mut Vec<Folder>, id: &str, name: &str) -> bool {
             for f in folders {
@@ -2081,6 +2098,7 @@ impl ApiClient {
                         requests: vec![],
                         subfolders: vec![],
                         description: String::new(),
+                        sync: SyncConfig::default(),
                     });
                     self.save_state();
                 }
@@ -2586,6 +2604,7 @@ impl eframe::App for ApiClient {
         self.render_runner_modal(ctx);
         self.render_backup_modal(ctx);
         self.render_sync_modal(ctx);
+        self.render_collection_settings_modal(ctx);
         self.render_env_modal(ctx);
         self.render_settings_modal(ctx);
         self.render_update_modal(ctx);
@@ -2657,6 +2676,7 @@ impl ApiClient {
                 id: Uuid::new_v4().to_string(),
                 name: src.name.clone(),
                 description: src.description.clone(),
+                sync: src.sync.clone(),
                 requests: src
                     .requests
                     .iter()

--- a/src/model.rs
+++ b/src/model.rs
@@ -385,6 +385,10 @@ pub struct Folder {
     /// page. Multiline; can be empty.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
+    /// Optional per-collection sync settings. Top-level collections can point
+    /// at different local Git repositories or OpenAPI specs.
+    #[serde(default, skip_serializing_if = "SyncConfig::is_empty")]
+    pub sync: SyncConfig,
 }
 
 #[derive(Serialize, Deserialize, Default)]
@@ -435,9 +439,18 @@ pub struct SyncConfig {
     /// lossless local/private exports per operation.
     #[serde(default)]
     pub include_secrets_in_git_workspace: bool,
-    /// Commit message used by the optional GitHub/local Git push workflow.
+    /// Commit message used by the optional local Git push workflow.
     #[serde(default = "default_git_commit_message")]
     pub git_commit_message: String,
+}
+
+impl SyncConfig {
+    pub fn is_empty(&self) -> bool {
+        self.git_workspace_dir.is_empty()
+            && self.openapi_spec_path.is_empty()
+            && !self.include_secrets_in_git_workspace
+            && self.git_commit_message == default_git_commit_message()
+    }
 }
 
 fn default_git_commit_message() -> String {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -592,8 +592,10 @@ mod tests {
                 requests: vec![request("b", "B")],
                 subfolders: vec![],
                 description: String::new(),
+                sync: crate::model::SyncConfig::default(),
             }],
             description: String::new(),
+            sync: crate::model::SyncConfig::default(),
         }];
 
         let all = collect_requests(&folders, None);

--- a/src/secret_scanner.rs
+++ b/src/secret_scanner.rs
@@ -387,6 +387,7 @@ fn redact_folder(folder: &Folder) -> Folder {
         requests: folder.requests.iter().map(redact_request).collect(),
         subfolders: folder.subfolders.iter().map(redact_folder).collect(),
         description: redact_text(&folder.description),
+        sync: folder.sync.clone(),
     }
 }
 
@@ -598,6 +599,7 @@ mod tests {
             requests: vec![request],
             subfolders: vec![],
             description: String::new(),
+            sync: crate::model::SyncConfig::default(),
         }]
     }
 

--- a/src/sync/apply.rs
+++ b/src/sync/apply.rs
@@ -1,3 +1,4 @@
+use crate::find_folder_by_id_mut;
 use crate::sync::job::SyncApply;
 use crate::{backup, ApiClient};
 use eframe::egui;
@@ -33,6 +34,28 @@ impl ApiClient {
                 self.prune_stale_tabs();
                 self.save_state();
                 self.show_toast(message);
+            }
+            Ok(SyncApply::ReplaceCollection {
+                folder_id,
+                mut folder,
+                message,
+            }) => {
+                if let Err(e) = backup::create_backup(&self.storage_path) {
+                    self.show_toast(format!("Sync aborted: backup failed: {}", e));
+                    return;
+                }
+                if let Some(existing) = find_folder_by_id_mut(&mut self.state.folders, &folder_id) {
+                    folder.sync = existing.sync.clone();
+                    *existing = folder;
+                    self.prune_stale_tabs();
+                    self.save_state();
+                    self.show_toast(message);
+                } else {
+                    self.show_toast("Sync aborted: collection no longer exists");
+                }
+            }
+            Ok(SyncApply::CollectionGitStatus { status }) => {
+                self.collection_git_status = status;
             }
             Ok(SyncApply::RefreshFolders { folders, updated }) => {
                 if let Err(e) = backup::create_backup(&self.storage_path) {

--- a/src/sync/git.rs
+++ b/src/sync/git.rs
@@ -22,7 +22,25 @@ impl fmt::Display for GitError {
 }
 
 pub(crate) fn run(repo_root: &Path, args: &[&str]) -> Result<(), GitError> {
-    let output = Command::new("git")
+    let output = command_output(repo_root, args)?;
+    output_result(args, output)
+}
+
+pub(crate) fn output(repo_root: &Path, args: &[&str]) -> Result<String, GitError> {
+    let output = command_output(repo_root, args)?;
+    output_result(
+        args,
+        Output {
+            status: output.status,
+            stdout: output.stdout.clone(),
+            stderr: output.stderr.clone(),
+        },
+    )?;
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn command_output(repo_root: &Path, args: &[&str]) -> Result<Output, GitError> {
+    Command::new("git")
         .arg("-C")
         .arg(repo_root)
         .args(args)
@@ -33,9 +51,7 @@ pub(crate) fn run(repo_root: &Path, args: &[&str]) -> Result<(), GitError> {
             } else {
                 GitError::StartFailed
             }
-        })?;
-
-    output_result(args, output)
+        })
 }
 
 fn output_result(args: &[&str], output: Output) -> Result<(), GitError> {

--- a/src/sync/job.rs
+++ b/src/sync/job.rs
@@ -11,6 +11,14 @@ pub(crate) enum SyncApply {
         folders: Vec<Folder>,
         message: String,
     },
+    ReplaceCollection {
+        folder_id: String,
+        folder: Folder,
+        message: String,
+    },
+    CollectionGitStatus {
+        status: String,
+    },
     RefreshFolders {
         folders: Vec<Folder>,
         updated: usize,

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -3,12 +3,203 @@ mod git;
 pub(crate) mod job;
 
 use crate::sync::job::SyncApply;
-use crate::{io, ApiClient};
+use crate::{find_folder_by_id, find_folder_by_id_mut, io, ApiClient};
 use std::path::PathBuf;
 
 pub(crate) use job::InFlightSync;
 
 impl ApiClient {
+    pub(crate) fn choose_collection_git_workspace_dir(&mut self, folder_id: &str) {
+        if let Some(path) = rfd::FileDialog::new().pick_folder() {
+            if let Some(folder) = find_folder_by_id_mut(&mut self.state.folders, folder_id) {
+                folder.sync.git_workspace_dir = path.display().to_string();
+                self.save_state();
+            }
+        }
+    }
+
+    pub(crate) fn choose_collection_openapi_spec_file(&mut self, folder_id: &str) {
+        if let Some(path) = rfd::FileDialog::new()
+            .add_filter("OpenAPI", &["json", "yaml", "yml"])
+            .add_filter("All files", &["*"])
+            .pick_file()
+        {
+            if let Some(folder) = find_folder_by_id_mut(&mut self.state.folders, folder_id) {
+                folder.sync.openapi_spec_path = path.display().to_string();
+                self.save_state();
+            }
+        }
+    }
+
+    pub(crate) fn export_collection_workspace_from_config(&mut self, folder_id: &str) {
+        let Some(folder) = find_folder_by_id(&self.state.folders, folder_id).cloned() else {
+            self.show_toast("Collection not found");
+            return;
+        };
+        let root = folder.sync.git_workspace_dir.trim();
+        if root.is_empty() {
+            self.show_toast("Choose a collection Git directory first");
+            return;
+        }
+        let root = PathBuf::from(root);
+        let options = collection_export_options(&folder.sync);
+        let include_secrets = folder.sync.include_secrets_in_git_workspace;
+        self.spawn_sync_job("Exporting collection workspace", move || {
+            let summary = io::git_workspace::export_workspace_to_dir(&[folder], &root, options)?;
+            let mode = if include_secrets {
+                "with secrets"
+            } else {
+                "masked"
+            };
+            Ok(SyncApply::Toast(format!(
+                "Exported collection workspace {} ({} request file(s))",
+                mode, summary.request_files
+            )))
+        });
+    }
+
+    pub(crate) fn import_collection_workspace_from_config(&mut self, folder_id: &str) {
+        let Some(folder) = find_folder_by_id(&self.state.folders, folder_id) else {
+            self.show_toast("Collection not found");
+            return;
+        };
+        let root = folder.sync.git_workspace_dir.trim();
+        if root.is_empty() {
+            self.show_toast("Choose a collection Git directory first");
+            return;
+        }
+        let root = PathBuf::from(root);
+        let folder_id = folder_id.to_string();
+        self.spawn_sync_job("Importing collection workspace", move || {
+            let mut folders = io::git_workspace::import_workspace_from_dir(&root)?;
+            if folders.len() != 1 {
+                return Err("Collection workspace must contain exactly one collection".to_string());
+            }
+            Ok(SyncApply::ReplaceCollection {
+                folder_id,
+                folder: folders.remove(0),
+                message: "Imported collection workspace".to_string(),
+            })
+        });
+    }
+
+    pub(crate) fn pull_collection_workspace_from_config(&mut self, folder_id: &str) {
+        let Some((root, folder_id)) = self.collection_git_root(folder_id) else {
+            return;
+        };
+        self.spawn_sync_job("Pulling collection remote", move || {
+            git::run(&root, &["pull", "--ff-only"]).map_err(|e| e.to_string())?;
+            let mut folders = io::git_workspace::import_workspace_from_dir(&root)?;
+            if folders.len() != 1 {
+                return Err("Collection workspace must contain exactly one collection".to_string());
+            }
+            Ok(SyncApply::ReplaceCollection {
+                folder_id,
+                folder: folders.remove(0),
+                message: "Pulled collection from Git remote".to_string(),
+            })
+        });
+    }
+
+    pub(crate) fn push_collection_workspace_from_config(&mut self, folder_id: &str) {
+        let Some((root, _)) = self.collection_git_root(folder_id) else {
+            return;
+        };
+        let Some(folder) = find_folder_by_id(&self.state.folders, folder_id).cloned() else {
+            self.show_toast("Collection not found");
+            return;
+        };
+        let options = collection_export_options(&folder.sync);
+        let message = folder.sync.git_commit_message.trim();
+        let message = if message.is_empty() {
+            "Sync Rusty Requester collection"
+        } else {
+            message
+        }
+        .to_string();
+        self.spawn_sync_job("Pushing collection remote", move || {
+            io::git_workspace::export_workspace_to_dir(&[folder], &root, options)?;
+            git::run(&root, &["add", "workspace.json", "requests"]).map_err(|e| e.to_string())?;
+            match git::run(&root, &["commit", "-m", &message]) {
+                Ok(_) | Err(git::GitError::NothingToCommit) => {}
+                Err(e) => return Err(e.to_string()),
+            }
+            git::run(&root, &["push"]).map_err(|e| e.to_string())?;
+            Ok(SyncApply::Toast(
+                "Pushed collection to Git remote".to_string(),
+            ))
+        });
+    }
+
+    pub(crate) fn refresh_collection_git_status_from_config(&mut self, folder_id: &str) {
+        let Some((root, _)) = self.collection_git_root(folder_id) else {
+            return;
+        };
+        self.spawn_sync_job("Reading collection Git changes", move || {
+            let status = git::output(&root, &["status", "--short"]).map_err(|e| e.to_string())?;
+            let diff_stat = git::output(&root, &["diff", "--stat"]).map_err(|e| e.to_string())?;
+            let status = if status.is_empty() {
+                "Working tree clean".to_string()
+            } else {
+                status
+            };
+            let status = if diff_stat.is_empty() {
+                status
+            } else {
+                format!("{}\n\n{}", status, diff_stat)
+            };
+            Ok(SyncApply::CollectionGitStatus { status })
+        });
+    }
+
+    pub(crate) fn refresh_collection_openapi_from_config(&mut self, folder_id: &str) {
+        const MAX_OPENAPI_REFRESH_BYTES: u64 = 10 * 1024 * 1024;
+
+        let Some(folder) = find_folder_by_id(&self.state.folders, folder_id).cloned() else {
+            self.show_toast("Collection not found");
+            return;
+        };
+        let path = folder.sync.openapi_spec_path.trim();
+        if path.is_empty() {
+            self.show_toast("Choose a collection OpenAPI spec first");
+            return;
+        }
+        let path = PathBuf::from(path);
+        let meta = match std::fs::symlink_metadata(&path) {
+            Ok(meta) => meta,
+            Err(e) => {
+                self.show_toast(format!("OpenAPI refresh failed: {}", e));
+                return;
+            }
+        };
+        if meta.file_type().is_symlink() {
+            self.show_toast("OpenAPI refresh failed: symlink specs are not allowed");
+            return;
+        }
+        if meta.len() > MAX_OPENAPI_REFRESH_BYTES {
+            self.show_toast("OpenAPI refresh failed: spec is larger than 10 MB");
+            return;
+        }
+        let folder_id = folder_id.to_string();
+        self.spawn_sync_job("Refreshing collection OpenAPI requests", move || {
+            let content = std::fs::read_to_string(&path)
+                .map_err(|e| format!("OpenAPI read failed: {}", e))?;
+            let mut folders = vec![folder];
+            let updated = io::refresh_openapi_folders(&mut folders, &content)?;
+            if updated == 0 {
+                Ok(SyncApply::Toast(
+                    "No OpenAPI-generated requests matched this collection".to_string(),
+                ))
+            } else {
+                Ok(SyncApply::ReplaceCollection {
+                    folder_id,
+                    folder: folders.remove(0),
+                    message: format!("Refreshed {} collection OpenAPI request(s)", updated),
+                })
+            }
+        });
+    }
+
     pub(crate) fn choose_git_workspace_dir(&mut self) {
         if !self.state.settings.workspace_sync_enabled {
             self.open_sync_or_settings();
@@ -204,6 +395,24 @@ impl ApiClient {
         Some(root)
     }
 
+    fn collection_git_root(&mut self, folder_id: &str) -> Option<(PathBuf, String)> {
+        let Some(folder) = find_folder_by_id(&self.state.folders, folder_id) else {
+            self.show_toast("Collection not found");
+            return None;
+        };
+        let root = folder.sync.git_workspace_dir.trim();
+        if root.is_empty() {
+            self.show_toast("Choose a collection Git directory first");
+            return None;
+        }
+        let root = PathBuf::from(root);
+        if !root.join(".git").is_dir() {
+            self.show_toast("Choose a Git repository root containing .git");
+            return None;
+        }
+        Some((root, folder_id.to_string()))
+    }
+
     fn spawn_sync_job<F>(&mut self, label: impl Into<String>, job: F)
     where
         F: FnOnce() -> Result<SyncApply, String> + Send + 'static,
@@ -213,5 +422,15 @@ impl ApiClient {
             return;
         }
         self.sync_in_flight = Some(job::spawn(label, job));
+    }
+}
+
+fn collection_export_options(sync: &crate::model::SyncConfig) -> io::git_workspace::ExportOptions {
+    io::git_workspace::ExportOptions {
+        secret_policy: if sync.include_secrets_in_git_workspace {
+            io::git_workspace::SecretPolicy::Include
+        } else {
+            io::git_workspace::SecretPolicy::Mask
+        },
     }
 }

--- a/src/ui/collection_settings.rs
+++ b/src/ui/collection_settings.rs
@@ -1,0 +1,276 @@
+use crate::theme::*;
+use crate::{find_folder_by_id, find_folder_by_id_mut, ApiClient};
+use eframe::egui;
+
+impl ApiClient {
+    pub(crate) fn render_collection_settings_modal(&mut self, ctx: &egui::Context) {
+        if !self.show_collection_settings_modal {
+            return;
+        }
+
+        let Some(folder_id) = self.collection_settings_folder_id.clone() else {
+            self.show_collection_settings_modal = false;
+            return;
+        };
+        let Some(folder) = find_folder_by_id(&self.state.folders, &folder_id).cloned() else {
+            self.show_collection_settings_modal = false;
+            self.show_toast("Collection not found");
+            return;
+        };
+
+        let mut open = self.show_collection_settings_modal;
+        let mut sync = folder.sync.clone();
+        let mut changed = false;
+        let mut choose_git_dir = false;
+        let mut choose_openapi_file = false;
+        let mut import_workspace = false;
+        let mut export_workspace = false;
+        let mut pull_remote = false;
+        let mut push_remote = false;
+        let mut refresh_git_status = false;
+        let mut refresh_openapi = false;
+
+        egui::Window::new("Collection Settings")
+            .collapsible(false)
+            .resizable(false)
+            .default_width(660.0)
+            .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
+            .open(&mut open)
+            .show(ctx, |ui| {
+                ui.set_min_width(620.0);
+                ui.label(
+                    egui::RichText::new(&folder.name)
+                        .size(16.0)
+                        .strong()
+                        .color(text()),
+                );
+                ui.label(
+                    egui::RichText::new(
+                        "Link this collection to a local folder or Git repository. Private \
+                         GitHub/GitLab/Bitbucket repos work through your existing local Git \
+                         credentials; Rusty Requester does not store Git provider tokens.",
+                    )
+                    .size(10.5)
+                    .color(muted()),
+                );
+                ui.add_space(12.0);
+
+                ui.label(
+                    egui::RichText::new("Collection directory")
+                        .size(12.0)
+                        .strong()
+                        .color(text()),
+                );
+                ui.label(
+                    egui::RichText::new(
+                        "Exports this collection as reviewable workspace files. Requests are \
+                         saved as pretty JSON with the .rr extension for readable pull requests.",
+                    )
+                    .size(10.5)
+                    .color(muted()),
+                );
+                ui.add_space(6.0);
+                ui.horizontal(|ui| {
+                    ui.label(egui::RichText::new("Directory").size(11.0).color(muted()));
+                    let response = ui.add(
+                        egui::TextEdit::singleline(&mut sync.git_workspace_dir)
+                            .hint_text(hint("/path/to/collection-repo"))
+                            .desired_width(ui.available_width() - 96.0),
+                    );
+                    changed |= response.changed();
+                    if ui.button("Choose...").clicked() {
+                        choose_git_dir = true;
+                    }
+                });
+
+                let git_ready = !sync.git_workspace_dir.trim().is_empty();
+                let is_git_repo = git_ready
+                    && std::path::Path::new(sync.git_workspace_dir.trim())
+                        .join(".git")
+                        .is_dir();
+                if git_ready && !is_git_repo {
+                    ui.label(
+                        egui::RichText::new(
+                            "Remote pull/push needs the repository root containing .git.",
+                        )
+                        .size(10.5)
+                        .color(C_ORANGE),
+                    );
+                }
+
+                ui.add_space(6.0);
+                if ui
+                    .checkbox(
+                        &mut sync.include_secrets_in_git_workspace,
+                        "Include secrets in collection exports",
+                    )
+                    .changed()
+                {
+                    changed = true;
+                }
+                ui.label(
+                    egui::RichText::new(
+                        "Keep this off for shared repos. A private repo is access control, not \
+                         encryption or a guarantee that secrets are safe to commit.",
+                    )
+                    .size(10.5)
+                    .color(muted()),
+                );
+
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    let busy = self.sync_in_flight.is_some();
+                    if ui
+                        .add_enabled(git_ready && !busy, egui::Button::new("Import from folder"))
+                        .clicked()
+                    {
+                        import_workspace = true;
+                    }
+                    if ui
+                        .add_enabled(git_ready && !busy, egui::Button::new("Export to folder"))
+                        .clicked()
+                    {
+                        export_workspace = true;
+                    }
+                });
+
+                ui.add_space(12.0);
+                ui.label(
+                    egui::RichText::new("Git remote")
+                        .size(12.0)
+                        .strong()
+                        .color(text()),
+                );
+                ui.horizontal(|ui| {
+                    ui.label(egui::RichText::new("Commit").size(11.0).color(muted()));
+                    let response = ui.add(
+                        egui::TextEdit::singleline(&mut sync.git_commit_message)
+                            .hint_text(hint("Sync Rusty Requester collection"))
+                            .desired_width(ui.available_width()),
+                    );
+                    changed |= response.changed();
+                });
+                ui.add_space(6.0);
+                ui.horizontal(|ui| {
+                    let busy = self.sync_in_flight.is_some();
+                    if ui
+                        .add_enabled(is_git_repo && !busy, egui::Button::new("Refresh changes"))
+                        .clicked()
+                    {
+                        refresh_git_status = true;
+                    }
+                    if ui
+                        .add_enabled(is_git_repo && !busy, egui::Button::new("Pull from remote"))
+                        .clicked()
+                    {
+                        pull_remote = true;
+                    }
+                    if ui
+                        .add_enabled(is_git_repo && !busy, egui::Button::new("Commit and push"))
+                        .clicked()
+                    {
+                        push_remote = true;
+                    }
+                });
+                if !self.collection_git_status.is_empty() {
+                    ui.add_space(8.0);
+                    egui::Frame::none()
+                        .fill(elevated())
+                        .stroke(egui::Stroke::new(1.0, border()))
+                        .rounding(egui::Rounding::same(6.0))
+                        .inner_margin(egui::Margin::symmetric(10.0, 8.0))
+                        .show(ui, |ui| {
+                            ui.set_max_height(120.0);
+                            egui::ScrollArea::vertical()
+                                .max_height(120.0)
+                                .show(ui, |ui| {
+                                    ui.monospace(&self.collection_git_status);
+                                });
+                        });
+                }
+
+                ui.add_space(14.0);
+                ui.separator();
+                ui.add_space(10.0);
+
+                ui.label(
+                    egui::RichText::new("OpenAPI refresh")
+                        .size(12.0)
+                        .strong()
+                        .color(text()),
+                );
+                ui.horizontal(|ui| {
+                    ui.label(egui::RichText::new("Spec file").size(11.0).color(muted()));
+                    let response = ui.add(
+                        egui::TextEdit::singleline(&mut sync.openapi_spec_path)
+                            .hint_text(hint("/path/to/openapi.yaml"))
+                            .desired_width(ui.available_width() - 96.0),
+                    );
+                    changed |= response.changed();
+                    if ui.button("Choose...").clicked() {
+                        choose_openapi_file = true;
+                    }
+                });
+                ui.add_space(6.0);
+                if ui
+                    .add_enabled(
+                        !sync.openapi_spec_path.trim().is_empty() && self.sync_in_flight.is_none(),
+                        egui::Button::new("Refresh collection from OpenAPI"),
+                    )
+                    .clicked()
+                {
+                    refresh_openapi = true;
+                }
+
+                if let Some(sync) = &self.sync_in_flight {
+                    ui.add_space(12.0);
+                    ui.horizontal(|ui| {
+                        ui.spinner();
+                        ui.label(egui::RichText::new(&sync.label).size(11.0).color(muted()));
+                    });
+                }
+
+                ui.add_space(14.0);
+                ui.separator();
+                ui.add_space(6.0);
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    if ui.button("Close").clicked() {
+                        self.show_collection_settings_modal = false;
+                    }
+                });
+            });
+
+        self.show_collection_settings_modal = open && self.show_collection_settings_modal;
+
+        if changed {
+            if let Some(folder) = find_folder_by_id_mut(&mut self.state.folders, &folder_id) {
+                folder.sync = sync;
+                self.save_state();
+            }
+        }
+        if choose_git_dir {
+            self.choose_collection_git_workspace_dir(&folder_id);
+        }
+        if choose_openapi_file {
+            self.choose_collection_openapi_spec_file(&folder_id);
+        }
+        if import_workspace {
+            self.import_collection_workspace_from_config(&folder_id);
+        }
+        if export_workspace {
+            self.export_collection_workspace_from_config(&folder_id);
+        }
+        if pull_remote {
+            self.pull_collection_workspace_from_config(&folder_id);
+        }
+        if push_remote {
+            self.push_collection_workspace_from_config(&folder_id);
+        }
+        if refresh_git_status {
+            self.refresh_collection_git_status_from_config(&folder_id);
+        }
+        if refresh_openapi {
+            self.refresh_collection_openapi_from_config(&folder_id);
+        }
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,6 +3,7 @@
 //! The `ApiClient` struct itself stays in `main.rs` (for now); these
 //! files only add `impl ApiClient { ... }` blocks.
 
+pub mod collection_settings;
 pub mod editor;
 pub mod modals;
 pub mod response;

--- a/src/ui/modals/menu.rs
+++ b/src/ui/modals/menu.rs
@@ -145,6 +145,7 @@ impl ApiClient {
                 requests: vec![],
                 subfolders: vec![],
                 description: String::new(),
+                sync: SyncConfig::default(),
             });
             self.save_state();
         }

--- a/src/ui/modals/paste.rs
+++ b/src/ui/modals/paste.rs
@@ -67,6 +67,7 @@ impl ApiClient {
                     requests: vec![],
                     subfolders: vec![],
                     description: String::new(),
+                    sync: SyncConfig::default(),
                 });
             }
 

--- a/src/ui/modals/save_draft.rs
+++ b/src/ui/modals/save_draft.rs
@@ -266,6 +266,7 @@ impl ApiClient {
                 requests: vec![],
                 subfolders: vec![],
                 description: String::new(),
+                sync: SyncConfig::default(),
             };
             let inserted = if parent_path.is_empty() {
                 self.state.folders.push(new_folder);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -246,6 +246,7 @@ impl ApiClient {
                         requests: vec![],
                         subfolders: vec![],
                         description: String::new(),
+                        sync: SyncConfig::default(),
                     });
                     self.save_state();
                 }
@@ -1077,6 +1078,7 @@ impl ApiClient {
                 ui.memory_mut(|m| m.toggle_popup(popup_id));
             }
             let mut open_overview = false;
+            let mut open_collection_settings = false;
             egui::popup::popup_below_widget(
                 ui,
                 popup_id,
@@ -1086,6 +1088,9 @@ impl ApiClient {
                     ui.set_min_width(180.0);
                     if ui.button("Open overview").clicked() {
                         open_overview = true;
+                    }
+                    if depth == 0 && ui.button("Collection settings...").clicked() {
+                        open_collection_settings = true;
                     }
                     ui.separator();
                     if ui.button("Add request").clicked() {
@@ -1121,6 +1126,10 @@ impl ApiClient {
             header_response.header_response.context_menu(|ui| {
                 if ui.button("Open overview").clicked() {
                     open_overview = true;
+                    ui.close_menu();
+                }
+                if depth == 0 && ui.button("Collection settings...").clicked() {
+                    open_collection_settings = true;
                     ui.close_menu();
                 }
                 ui.separator();
@@ -1200,6 +1209,7 @@ impl ApiClient {
                         requests: vec![],
                         subfolders: vec![],
                         description: String::new(),
+                        sync: SyncConfig::default(),
                     });
                 }
                 self.save_state();
@@ -1209,6 +1219,9 @@ impl ApiClient {
             }
             if open_overview {
                 self.open_folder_overview(&folder_id);
+            }
+            if open_collection_settings {
+                self.open_collection_settings(&folder_id);
             }
             if delete_folder {
                 self.delete_folder(&folder_id);


### PR DESCRIPTION
## Summary
- add collection settings for linking top-level collections to local Git repositories
- add Git UI actions for status/diff summary, pull, export, commit, and push using local Git credentials
- export reviewable .rr request files while preserving legacy .json import compatibility
- document collection Git sync, private repo behavior, OpenAPI refresh, and the workspace format

## Tests
- cargo fmt --check
- cargo test -q
- cargo clippy --all-targets -- -D warnings
- git diff --check