### PR TITLE
Add native reviewable workspace format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Added
+- **Native reviewable workspace files.** Git workspace exports now write `.rr`
+  request files in Rusty Requester's own compact text format instead of plain
+  JSON, keep legacy `.json` request imports working, and include
+  `environments/*.rrenv` plus a Git-safe `.gitignore` for local secret overlays.
+- **Collection export mask rules.** Collection Settings now lets users choose
+  comma-separated key/header/env patterns that should always be masked, plus
+  patterns that are safe to keep readable in Git exports.
+- **Cleaner update progress foundation.** In-app update progress is being
+  reshaped around compact status and animation primitives instead of log-first
+  modal chrome.
+
+### Fixed
+- **Manual update check accuracy.** Settings no longer reports "latest" when
+  the GitHub latest-release check failed; failures now show an explicit message.
+- **Mobile docs navigation.** The GitHub Pages usage docs now keep navigation
+  available on mobile through a native expandable section menu.
+
 ## [0.26.0] — 2026-06-17
 
 ### Added

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -152,14 +152,17 @@ the original values.
 - Before collection export, Rusty Requester runs a local-only secret scan for common API keys, bearer/JWT-style tokens, OAuth/basic auth secrets, cookies, and sensitive key names such as `Authorization`, `token`, `password`, `client_secret`, and `api_key`. If likely secrets are found, you can cancel, continue with the original export, or export a redacted copy with likely secret values replaced by `[REDACTED]`. This scanner never uploads export content. It is heuristic: unusual secret formats may be missed, and placeholder or example values may still produce false positives.
 - **Git workspace format** — core import/export code can write a deterministic
   directory with `workspace.json` plus one readable `.rr` request file per
-  request. `.rr` files contain pretty JSON, preserve IDs for Git round-trips,
-  and mask secrets by default. See
+  request and one `.rrenv` file per environment. `.rr` is Rusty Requester's
+  compact text format, preserves IDs for Git round-trips, keeps legacy JSON
+  request imports working, and masks secrets by default. See
   [`GIT_WORKSPACE_FORMAT.md`](./GIT_WORKSPACE_FORMAT.md) for layout and
   merge-conflict expectations.
 - **Collection-level Git UI** — each top-level collection can point at its own
   local Git repository from **Collection settings...**. The free Git panel can
   show status/diff summary, pull from remote, export the collection, commit,
-  and push through your existing local Git credentials.
+  and push through your existing local Git credentials. Collection settings also
+  include custom mask/allow key patterns so shared headers like `platform` can
+  stay readable while `x-api-key` or similar values are forced masked.
 - **Workspace Sync** — optional, off by default in Settings. When enabled,
   **Workspace Sync…** lets you pull from a Git workspace directory, push a
   masked Git workspace snapshot, pull/push a Git remote through your local Git

--- a/docs/GIT_WORKSPACE_FORMAT.md
+++ b/docs/GIT_WORKSPACE_FORMAT.md
@@ -15,13 +15,22 @@ requests/
     002-other-request-other-request-id.rr
     001-nested-folder-folder-id/
       001-nested-request-request-id.rr
+environments/
+  001-local-env-local.rrenv
+.gitignore
 ```
 
 - `workspace.json` is the manifest. It records the format name, version, secret
-  policy, ordered folder tree, and each request file path.
-- Each request lives in its own readable `.rr` file under `requests/`. The
-  contents are still pretty JSON, so diffs stay readable in GitHub, GitLab,
-  Bitbucket, terminals, and normal editors.
+  policy, ordered folder tree, request file paths, and environment file paths.
+- Each request lives in its own readable `.rr` file under `requests/`. `.rr` is
+  a compact Rusty Requester text format: scalar metadata at the top, table-like
+  row sections for params / headers / cookies, and fenced blocks only for raw
+  bodies or structured extension data.
+- Each environment lives in its own `.rrenv` file under `environments/`.
+  Variables are row-based and cookies remain structured data. Default exports
+  mask secret-looking values.
+- Export writes a `.gitignore` that excludes future local secret overlays:
+  `secrets/` and `*.rrsecret`.
 - Imports remain backward-compatible with older workspaces whose manifest
   points at `.json` request files.
 - Folder and request file names include a 1-based order prefix, a readable slug,
@@ -32,16 +41,16 @@ requests/
 ## Determinism
 
 For the same workspace data and export options, Rusty Requester writes the same
-manifest content, request file paths, JSON field order, and trailing newlines.
-The manifest preserves the app's visible collection, folder, and request order;
-request files are written in sorted path order.
+manifest content, request/environment file paths, field order, block delimiters,
+and trailing newlines. The manifest preserves the app's visible collection,
+folder, and request order; files are written in sorted path order.
 
 ## IDs
 
-Folder and request IDs are preserved in both the manifest and request files.
-Import rejects a request file if its `id` does not match the manifest entry that
-points at it. This catches common merge mistakes such as resolving a manifest
-path to the wrong request body.
+Folder, request, and environment IDs are preserved in both the manifest and
+native files. Import rejects a request or environment file if its `id` does not
+match the manifest entry that points at it. This catches common merge mistakes
+such as resolving a manifest path to the wrong file.
 
 ## Secrets
 
@@ -49,6 +58,10 @@ The default export policy is `masked`.
 
 - Sensitive auth values, known sensitive row keys, cookies, form fields, and
   OAuth cached tokens are masked with the shared privacy helpers.
+- Environment variable values and cookies are masked by default.
+- Collection Settings can add custom comma-separated mask patterns for keys
+  such as `x-api-key`, and allow patterns for safe shared keys such as
+  `platform` or `env`. Allow patterns win over built-in and custom mask rules.
 - URL query strings and fragments are redacted by default.
 - Raw bodies are not parsed for secrets; keep credentials in auth, params,
   headers, cookies, or form fields if you want automatic masking.
@@ -62,8 +75,8 @@ in the files, including masked placeholders.
 Expected conflict shape:
 
 - Two people edit different request files: Git usually merges cleanly.
-- Two people edit the same request file: resolve the `.rr` JSON object like any other
-  small source file, keeping the original `id`.
+- Two people edit the same request file: resolve the `.rr` sections like any
+  other small source file, keeping the original `id`.
 - Two people reorder or move requests: resolve `workspace.json` first because it
   owns ordering and file paths.
 - A request file and manifest entry disagree on ID after conflict resolution:
@@ -72,5 +85,5 @@ Expected conflict shape:
   after resolving conflicts if you want to normalize paths and ordering.
 
 The safest manual resolution rule is: preserve IDs, keep one manifest entry per
-request, and make every manifest `path` point to a `.rr` or legacy `.json` file
-with the same `id`.
+request/environment, and make every manifest `path` point to a `.rr`,
+`.rrenv`, or legacy `.json` file with the same `id`.

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -143,6 +143,52 @@ th { color: var(--dim); font-size: 0.78rem; letter-spacing: 0.06em; text-transfo
   padding: 14px 18px;
 }
 .topbar .brand { margin: 0; }
+.mobile-nav {
+  margin-top: 12px;
+}
+.mobile-nav summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 38px;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  list-style: none;
+  font-weight: 650;
+}
+.mobile-nav summary::-webkit-details-marker { display: none; }
+.mobile-nav summary::after {
+  content: "⌄";
+  color: var(--muted);
+}
+.mobile-nav[open] summary::after {
+  content: "⌃";
+}
+.mobile-nav .mobile-nav-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+  margin-top: 8px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+.mobile-nav a {
+  padding: 7px 8px;
+  border-radius: 6px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+.mobile-nav a:hover {
+  background: var(--surface-2);
+  color: var(--text);
+  text-decoration: none;
+}
 .content {
   max-width: 1060px;
   width: 100%;
@@ -274,11 +320,38 @@ th { color: var(--dim); font-size: 0.78rem; letter-spacing: 0.06em; text-transfo
   .grid, .grid-3 { grid-template-columns: 1fr; }
   h2 { margin-top: 44px; }
 }
+@media (max-width: 560px) {
+  .mobile-nav .mobile-nav-grid { grid-template-columns: 1fr; }
+}
 </style>
 </head>
 <body>
 <div class="topbar">
   <a class="brand" href="./index.html"><img src="./icon.svg" alt="" />Rusty Requester Docs</a>
+  <details class="mobile-nav">
+    <summary>Sections</summary>
+    <nav class="mobile-nav-grid">
+      <a href="#overview">Overview</a>
+      <a href="#install">Install and update</a>
+      <a href="#first-request">First request</a>
+      <a href="#workspace">Workspace model</a>
+      <a href="#request-builder">Request builder</a>
+      <a href="#auth">Authentication</a>
+      <a href="#environments">Environments</a>
+      <a href="#responses">Responses</a>
+      <a href="#collections">Collections</a>
+      <a href="#runner">Collection Runner</a>
+      <a href="#curl">cURL and snippets</a>
+      <a href="#openapi">OpenAPI and Postman</a>
+      <a href="#git-workspace">Git workspace export</a>
+      <a href="#safe-sharing">Safe sharing</a>
+      <a href="#backups">Backups</a>
+      <a href="#shortcuts">Shortcuts</a>
+      <a href="#settings">Settings</a>
+      <a href="#troubleshooting">Troubleshooting</a>
+      <a href="#links">More links</a>
+    </nav>
+  </details>
 </div>
 
 <div class="layout">
@@ -604,12 +677,16 @@ requests/
   001-my-api-collection-id/
     001-login-request-id.rr
     001-users-folder-id/
-      001-list-users-request-id.rr</code></pre>
+      001-list-users-request-id.rr
+environments/
+  001-local-env-local.rrenv</code></pre>
       <ul>
-        <li>One readable <code>.rr</code> file per request, containing pretty JSON.</li>
+        <li>One readable native <code>.rr</code> file per request.</li>
+        <li>One readable <code>.rrenv</code> file per environment.</li>
         <li>Stable IDs for round trips.</li>
         <li>Deterministic ordering for cleaner diffs.</li>
         <li>Secret masking by default for safer commits.</li>
+        <li>Collection-level mask/allow key patterns for shared headers and env keys.</li>
         <li>Free Git UI: status/diff summary, pull, export, commit, and push.</li>
       </ul>
       <p>The older <strong>Workspace Sync...</strong> modal is still available for whole-workspace import/export, but collection settings are the recommended path for team Git review.</p>

--- a/src/io/git_workspace.rs
+++ b/src/io/git_workspace.rs
@@ -1,4 +1,4 @@
-use crate::model::{Auth, BodyExt, Folder, KvRow, OAuth2State, Request};
+use crate::model::{Auth, BodyExt, Environment, Folder, KvRow, OAuth2State, Request};
 use crate::privacy::{is_sensitive_key, mask_secret_value, redact_url_query_and_fragment};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeSet;
@@ -12,7 +12,9 @@ const FORMAT_NAME: &str = "rusty-requester-git-workspace";
 const FORMAT_VERSION: u32 = 1;
 const MANIFEST_FILE: &str = "workspace.json";
 const REQUESTS_DIR: &str = "requests";
+const ENVIRONMENTS_DIR: &str = "environments";
 const REQUEST_FILE_EXTENSION: &str = "rr";
+const ENV_FILE_EXTENSION: &str = "rrenv";
 const MAX_REQUEST_FILES: usize = 5_000;
 const MAX_FOLDER_DEPTH: usize = 32;
 const MAX_IMPORT_BYTES: u64 = 50 * 1024 * 1024;
@@ -27,23 +29,32 @@ pub enum SecretPolicy {
     Include,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExportOptions {
     pub secret_policy: SecretPolicy,
+    pub mask_rules: MaskRules,
 }
 
 impl Default for ExportOptions {
     fn default() -> Self {
         Self {
             secret_policy: SecretPolicy::Mask,
+            mask_rules: MaskRules::default(),
         }
     }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct MaskRules {
+    pub mask_patterns: Vec<String>,
+    pub allow_patterns: Vec<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ExportSummary {
     pub manifest_path: PathBuf,
     pub request_files: usize,
+    pub environment_files: usize,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -51,6 +62,8 @@ struct Manifest {
     format: String,
     version: u32,
     secrets: ManifestSecretPolicy,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    environments: Vec<ManifestEnvironment>,
     folders: Vec<ManifestFolder>,
 }
 
@@ -79,29 +92,41 @@ struct ManifestRequest {
     path: String,
 }
 
+#[derive(Serialize, Deserialize)]
+struct ManifestEnvironment {
+    id: String,
+    path: String,
+}
+
+#[allow(dead_code)]
 pub fn export_workspace_to_dir(
     folders: &[Folder],
+    root: &Path,
+    options: ExportOptions,
+) -> Result<ExportSummary, String> {
+    export_workspace_with_environments_to_dir(folders, &[], root, options)
+}
+
+pub fn export_workspace_with_environments_to_dir(
+    folders: &[Folder],
+    environments: &[Environment],
     root: &Path,
     options: ExportOptions,
 ) -> Result<ExportSummary, String> {
     fs::create_dir_all(root).map_err(|e| format!("Create export directory: {}", e))?;
 
     let requests_root = root.join(REQUESTS_DIR);
-    if requests_root.exists() {
-        let meta = fs::symlink_metadata(&requests_root)
-            .map_err(|e| format!("Inspect request directory: {}", e))?;
-        if meta.file_type().is_symlink() {
-            return Err("Refusing to replace symlinked requests directory".to_string());
-        }
-        if !meta.is_dir() {
-            return Err("Refusing to replace non-directory requests path".to_string());
-        }
-        fs::remove_dir_all(&requests_root).map_err(|e| format!("Clean request files: {}", e))?;
-    }
+    replace_managed_dir(&requests_root, "requests")?;
     fs::create_dir_all(&requests_root).map_err(|e| format!("Create request directory: {}", e))?;
 
+    let environments_root = root.join(ENVIRONMENTS_DIR);
+    replace_managed_dir(&environments_root, "environments")?;
+    fs::create_dir_all(&environments_root)
+        .map_err(|e| format!("Create environments directory: {}", e))?;
+    write_workspace_gitignore(root)?;
+
     let mut request_files = Vec::new();
-    let folders = manifest_folders(folders, options, &mut request_files)?;
+    let folders = manifest_folders(folders, options.clone(), &mut request_files)?;
     request_files.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
 
     let mut seen_paths = BTreeSet::new();
@@ -116,8 +141,30 @@ pub fn export_workspace_to_dir(
         if let Some(parent) = full_path.parent() {
             fs::create_dir_all(parent).map_err(|e| format!("Create request directory: {}", e))?;
         }
-        write_json_file(&full_path, &request_file.request)
+        write_text_file(&full_path, &request_to_rr(&request_file.request)?)
             .map_err(|e| format!("Write {}: {}", full_path.display(), e))?;
+    }
+
+    let mut environment_files = manifest_environments(environments, options.clone());
+    environment_files.sort_by(|a, b| a.relative_path.cmp(&b.relative_path));
+    let mut seen_env_paths = BTreeSet::new();
+    for environment_file in &environment_files {
+        if !seen_env_paths.insert(environment_file.relative_path.clone()) {
+            return Err(format!(
+                "Duplicate environment export path generated: {}",
+                environment_file.relative_path.display()
+            ));
+        }
+        let full_path = root.join(&environment_file.relative_path);
+        if let Some(parent) = full_path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Create environment directory: {}", e))?;
+        }
+        write_text_file(
+            &full_path,
+            &environment_to_rrenv(&environment_file.environment)?,
+        )
+        .map_err(|e| format!("Write {}: {}", full_path.display(), e))?;
     }
 
     let manifest = Manifest {
@@ -127,6 +174,15 @@ pub fn export_workspace_to_dir(
             SecretPolicy::Mask => ManifestSecretPolicy::Masked,
             SecretPolicy::Include => ManifestSecretPolicy::Included,
         },
+        environments: environment_files
+            .iter()
+            .map(|env| {
+                Ok(ManifestEnvironment {
+                    id: env.environment.id.clone(),
+                    path: path_to_manifest_string(&env.relative_path)?,
+                })
+            })
+            .collect::<Result<Vec<_>, String>>()?,
         folders,
     };
     let manifest_path = root.join(MANIFEST_FILE);
@@ -136,10 +192,22 @@ pub fn export_workspace_to_dir(
     Ok(ExportSummary {
         manifest_path,
         request_files: request_files.len(),
+        environment_files: environment_files.len(),
     })
 }
 
+#[allow(dead_code)]
 pub fn import_workspace_from_dir(root: &Path) -> Result<Vec<Folder>, String> {
+    import_workspace_bundle_from_dir(root).map(|bundle| bundle.folders)
+}
+
+#[derive(Clone, Debug)]
+pub struct WorkspaceBundle {
+    pub folders: Vec<Folder>,
+    pub environments: Vec<Environment>,
+}
+
+pub fn import_workspace_bundle_from_dir(root: &Path) -> Result<WorkspaceBundle, String> {
     let manifest_path = root.join(MANIFEST_FILE);
     let mut budget = ImportBudget::default();
     let manifest_content = read_bounded_file(&manifest_path, &mut budget)?;
@@ -159,12 +227,35 @@ pub fn import_workspace_from_dir(root: &Path) -> Result<Vec<Folder>, String> {
         ));
     }
 
-    import_manifest_folders(root, &manifest.folders, &mut budget, 0)
+    Ok(WorkspaceBundle {
+        folders: import_manifest_folders(root, &manifest.folders, &mut budget, 0)?,
+        environments: import_manifest_environments(root, &manifest.environments, &mut budget)?,
+    })
 }
 
 struct RequestFile {
     relative_path: PathBuf,
     request: Request,
+}
+
+struct EnvironmentFile {
+    relative_path: PathBuf,
+    environment: Environment,
+}
+
+fn replace_managed_dir(path: &Path, label: &str) -> Result<(), String> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let meta =
+        fs::symlink_metadata(path).map_err(|e| format!("Inspect {} directory: {}", label, e))?;
+    if meta.file_type().is_symlink() {
+        return Err(format!("Refusing to replace symlinked {} directory", label));
+    }
+    if !meta.is_dir() {
+        return Err(format!("Refusing to replace non-directory {} path", label));
+    }
+    fs::remove_dir_all(path).map_err(|e| format!("Clean {} files: {}", label, e))
 }
 
 fn manifest_folders(
@@ -176,7 +267,7 @@ fn manifest_folders(
     for (index, folder) in folders.iter().enumerate() {
         out.push(manifest_folder(
             folder,
-            options,
+            options.clone(),
             request_files,
             Vec::new(),
             index,
@@ -213,7 +304,7 @@ fn manifest_folder(
         });
         request_files.push(RequestFile {
             relative_path: request_path,
-            request: export_request(request, options.secret_policy),
+            request: export_request(request, &options),
         });
     }
 
@@ -221,7 +312,7 @@ fn manifest_folder(
     for (sub_index, subfolder) in folder.subfolders.iter().enumerate() {
         subfolders.push(manifest_folder(
             subfolder,
-            options,
+            options.clone(),
             request_files,
             parent_components.clone(),
             sub_index,
@@ -263,10 +354,14 @@ fn import_manifest_folders(
             }
 
             let relative = validate_manifest_path(&request_ref.path)?;
-            let path = root.join(relative);
+            let path = root.join(&relative);
             let content = read_bounded_file(&path, budget)?;
-            let request: Request = serde_json::from_str(&content)
-                .map_err(|e| format!("Parse {}: {}", path.display(), e))?;
+            let request = if relative.extension() == Some(OsStr::new("json")) {
+                serde_json::from_str(&content)
+                    .map_err(|e| format!("Parse {}: {}", path.display(), e))?
+            } else {
+                rr_to_request(&content).map_err(|e| format!("Parse {}: {}", path.display(), e))?
+            };
             if request.id != request_ref.id {
                 return Err(format!(
                     "Request ID mismatch for {}: manifest has {}, file has {}",
@@ -288,10 +383,91 @@ fn import_manifest_folders(
     Ok(out)
 }
 
+fn manifest_environments(
+    environments: &[Environment],
+    options: ExportOptions,
+) -> Vec<EnvironmentFile> {
+    environments
+        .iter()
+        .enumerate()
+        .map(|(index, environment)| {
+            let mut path = PathBuf::from(ENVIRONMENTS_DIR);
+            path.push(format!(
+                "{}.{}",
+                path_component(index, &environment.name, &environment.id, "environment"),
+                ENV_FILE_EXTENSION
+            ));
+            EnvironmentFile {
+                relative_path: path,
+                environment: export_environment(environment, &options),
+            }
+        })
+        .collect()
+}
+
+fn import_manifest_environments(
+    root: &Path,
+    environments: &[ManifestEnvironment],
+    budget: &mut ImportBudget,
+) -> Result<Vec<Environment>, String> {
+    let mut out = Vec::with_capacity(environments.len());
+    for environment_ref in environments {
+        let relative = validate_environment_path(&environment_ref.path)?;
+        let path = root.join(relative);
+        let content = read_bounded_file(&path, budget)?;
+        let environment = rrenv_to_environment(&content)
+            .map_err(|e| format!("Parse {}: {}", path.display(), e))?;
+        if environment.id != environment_ref.id {
+            return Err(format!(
+                "Environment ID mismatch for {}: manifest has {}, file has {}",
+                environment_ref.path, environment_ref.id, environment.id
+            ));
+        }
+        out.push(environment);
+    }
+    Ok(out)
+}
+
 #[derive(Default)]
 struct ImportBudget {
     total_bytes: u64,
     request_files: usize,
+}
+
+fn validate_environment_path(path: &str) -> Result<PathBuf, String> {
+    let relative = PathBuf::from(path);
+    if relative.is_absolute() {
+        return Err(format!(
+            "Workspace environment path must be relative: {}",
+            path
+        ));
+    }
+    if relative.extension() != Some(OsStr::new(ENV_FILE_EXTENSION)) {
+        return Err(format!(
+            "Workspace environment path must be a .{} file: {}",
+            ENV_FILE_EXTENSION, path
+        ));
+    }
+
+    let mut components = relative.components();
+    match components.next() {
+        Some(Component::Normal(part)) if part == OsStr::new(ENVIRONMENTS_DIR) => {}
+        _ => {
+            return Err(format!(
+                "Workspace environment path must live under {}: {}",
+                ENVIRONMENTS_DIR, path
+            ));
+        }
+    }
+
+    for component in components {
+        match component {
+            Component::Normal(_) => {}
+            _ => return Err(format!("Workspace environment path escapes root: {}", path)),
+        }
+    }
+
+    Ok(relative)
 }
 
 fn read_bounded_file(path: &Path, budget: &mut ImportBudget) -> Result<String, String> {
@@ -357,47 +533,463 @@ fn validate_manifest_path(path: &str) -> Result<PathBuf, String> {
     Ok(relative)
 }
 
-fn export_request(request: &Request, secret_policy: SecretPolicy) -> Request {
-    match secret_policy {
+fn export_request(request: &Request, options: &ExportOptions) -> Request {
+    match options.secret_policy {
         SecretPolicy::Include => request.clone(),
-        SecretPolicy::Mask => mask_request(request),
+        SecretPolicy::Mask => mask_request(request, &options.mask_rules),
     }
 }
 
-fn mask_request(request: &Request) -> Request {
+fn export_environment(environment: &Environment, options: &ExportOptions) -> Environment {
+    match options.secret_policy {
+        SecretPolicy::Include => environment.clone(),
+        SecretPolicy::Mask => {
+            let mut environment = environment.clone();
+            environment.variables = mask_rows(&environment.variables, &options.mask_rules);
+            environment.cookies = environment
+                .cookies
+                .into_iter()
+                .map(|mut cookie| {
+                    cookie.value = mask_secret_value(&cookie.value);
+                    cookie
+                })
+                .collect();
+            environment
+        }
+    }
+}
+
+fn request_to_rr(request: &Request) -> Result<String, String> {
+    let mut out = String::new();
+    out.push_str("rr 1\n");
+    push_field(&mut out, "id", &request.id)?;
+    push_field(&mut out, "name", &request.name)?;
+    push_field(&mut out, "description", &request.description)?;
+    push_field(&mut out, "method", &request.method.to_string())?;
+    push_field(&mut out, "url", &request.url)?;
+    push_rows(&mut out, "query", &request.query_params)?;
+    push_rows(&mut out, "path", &request.path_params)?;
+    push_rows(&mut out, "headers", &request.headers)?;
+    push_rows(&mut out, "cookies", &request.cookies)?;
+    push_text_block(&mut out, "body", &request.body)?;
+    push_json_block(&mut out, "body_ext", &request.body_ext)?;
+    push_json_block(&mut out, "auth", &request.auth)?;
+    push_json_block(&mut out, "extractors", &request.extractors)?;
+    push_json_block(&mut out, "assertions", &request.assertions)?;
+    push_json_block(&mut out, "source", &request.source)?;
+    Ok(out)
+}
+
+fn rr_to_request(content: &str) -> Result<Request, String> {
+    let mut doc = RrDocument::parse(content, "rr 1")?;
+    let id = doc.take_required_field("id")?;
+    let name = doc.take_required_field("name")?;
+    let description = doc.take_field("description")?.unwrap_or_default();
+    let method = doc.take_required_field("method")?;
+    let method = serde_json::from_value(serde_json::Value::String(method))
+        .map_err(|e| format!("Invalid method: {}", e))?;
+    let url = doc.take_required_field("url")?;
+    let query_params = doc.take_rows("query")?;
+    let path_params = doc.take_rows("path")?;
+    let headers = doc.take_rows("headers")?;
+    let cookies = doc.take_rows("cookies")?;
+    let body = doc.take_text_block("body")?.unwrap_or_default();
+    let body_ext = doc
+        .take_json_block("body_ext")?
+        .map(|value| serde_json::from_value(value).map_err(|e| format!("Invalid body_ext: {}", e)))
+        .transpose()?
+        .unwrap_or(None);
+    let auth = doc
+        .take_json_block("auth")?
+        .map(|value| serde_json::from_value(value).map_err(|e| format!("Invalid auth: {}", e)))
+        .transpose()?
+        .unwrap_or_default();
+    let extractors = doc
+        .take_json_block("extractors")?
+        .map(|value| {
+            serde_json::from_value(value).map_err(|e| format!("Invalid extractors: {}", e))
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let assertions = doc
+        .take_json_block("assertions")?
+        .map(|value| {
+            serde_json::from_value(value).map_err(|e| format!("Invalid assertions: {}", e))
+        })
+        .transpose()?
+        .unwrap_or_default();
+    let source = doc
+        .take_json_block("source")?
+        .map(|value| serde_json::from_value(value).map_err(|e| format!("Invalid source: {}", e)))
+        .transpose()?
+        .unwrap_or(None);
+    doc.reject_unknown()?;
+
+    Ok(Request {
+        id,
+        name,
+        description,
+        method,
+        url,
+        query_params,
+        path_params,
+        headers,
+        cookies,
+        body,
+        body_ext,
+        auth,
+        extractors,
+        assertions,
+        source,
+    })
+}
+
+fn environment_to_rrenv(environment: &Environment) -> Result<String, String> {
+    let mut out = String::new();
+    out.push_str("rrenv 1\n");
+    push_field(&mut out, "id", &environment.id)?;
+    push_field(&mut out, "name", &environment.name)?;
+    push_rows(&mut out, "variables", &environment.variables)?;
+    push_json_block(&mut out, "cookies", &environment.cookies)?;
+    Ok(out)
+}
+
+fn rrenv_to_environment(content: &str) -> Result<Environment, String> {
+    let mut doc = RrDocument::parse(content, "rrenv 1")?;
+    let id = doc.take_required_field("id")?;
+    let name = doc.take_required_field("name")?;
+    let variables = doc.take_rows("variables")?;
+    let cookies = doc
+        .take_json_block("cookies")?
+        .map(|value| serde_json::from_value(value).map_err(|e| format!("Invalid cookies: {}", e)))
+        .transpose()?
+        .unwrap_or_default();
+    doc.reject_unknown()?;
+
+    Ok(Environment {
+        id,
+        name,
+        variables,
+        cookies,
+    })
+}
+
+fn push_field(out: &mut String, key: &str, value: &str) -> Result<(), String> {
+    out.push_str(key);
+    out.push_str(": ");
+    out.push_str(&json_string(value)?);
+    out.push('\n');
+    Ok(())
+}
+
+fn push_rows(out: &mut String, section: &str, rows: &[KvRow]) -> Result<(), String> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    out.push('\n');
+    out.push('[');
+    out.push_str(section);
+    out.push_str("]\n");
+    for row in rows {
+        out.push(if row.enabled { '+' } else { '~' });
+        out.push(' ');
+        out.push_str(&json_string(&row.key)?);
+        out.push('\t');
+        out.push_str(&json_string(&row.value)?);
+        out.push('\t');
+        out.push_str(&json_string(&row.description)?);
+        out.push('\n');
+    }
+    Ok(())
+}
+
+fn push_text_block(out: &mut String, section: &str, value: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Ok(());
+    }
+    push_block(out, section, "text", value)
+}
+
+fn push_json_block<T: Serialize>(out: &mut String, section: &str, value: &T) -> Result<(), String> {
+    let value = serde_json::to_value(value).map_err(|e| e.to_string())?;
+    if value.is_null()
+        || value == serde_json::json!([])
+        || value == serde_json::json!({})
+        || value == serde_json::json!({"type": "None"})
+    {
+        return Ok(());
+    }
+    let text = serde_json::to_string_pretty(&value).map_err(|e| e.to_string())?;
+    push_block(out, section, "json", &text)
+}
+
+fn push_block(out: &mut String, section: &str, kind: &str, value: &str) -> Result<(), String> {
+    let delimiter = block_delimiter(value);
+    out.push('\n');
+    out.push('[');
+    out.push_str(section);
+    out.push_str("]\n");
+    out.push_str(kind);
+    out.push_str(" <<");
+    out.push_str(&delimiter);
+    out.push('\n');
+    out.push_str(value);
+    if !value.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push_str(&delimiter);
+    out.push('\n');
+    Ok(())
+}
+
+fn block_delimiter(value: &str) -> String {
+    let mut suffix = 0;
+    loop {
+        let candidate = if suffix == 0 {
+            "RR_BLOCK".to_string()
+        } else {
+            format!("RR_BLOCK_{}", suffix)
+        };
+        if !value.lines().any(|line| line == candidate) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
+fn json_string(value: &str) -> Result<String, String> {
+    serde_json::to_string(value).map_err(|e| e.to_string())
+}
+
+#[derive(Default)]
+struct RrDocument {
+    fields: std::collections::BTreeMap<String, String>,
+    sections: std::collections::BTreeMap<String, RrSection>,
+}
+
+#[derive(Default)]
+struct RrSection {
+    rows: Vec<KvRow>,
+    block: Option<RrBlock>,
+}
+
+struct RrBlock {
+    kind: String,
+    value: String,
+}
+
+impl RrDocument {
+    fn parse(content: &str, header: &str) -> Result<Self, String> {
+        let lines: Vec<&str> = content.lines().collect();
+        if lines.first().map(|line| line.trim()) != Some(header) {
+            return Err(format!("Expected {} header", header));
+        }
+
+        let mut doc = RrDocument::default();
+        let mut section: Option<String> = None;
+        let mut index = 1;
+        while index < lines.len() {
+            let line = lines[index];
+            let trimmed = line.trim();
+            index += 1;
+            if trimmed.is_empty() || trimmed.starts_with('#') {
+                continue;
+            }
+            if let Some(name) = trimmed.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
+                section = Some(name.to_string());
+                doc.sections.entry(name.to_string()).or_default();
+                continue;
+            }
+
+            if let Some(section_name) = &section {
+                if let Some((kind, rest)) = trimmed.split_once(" <<") {
+                    let marker = rest.trim();
+                    if marker.is_empty() {
+                        return Err("Missing block marker".to_string());
+                    }
+                    let mut value = String::new();
+                    let mut closed = false;
+                    while index < lines.len() {
+                        let block_line = lines[index];
+                        index += 1;
+                        if block_line == marker {
+                            closed = true;
+                            break;
+                        }
+                        value.push_str(block_line);
+                        value.push('\n');
+                    }
+                    if !closed {
+                        return Err(format!("Unclosed block in [{}]", section_name));
+                    }
+                    if value.ends_with('\n') {
+                        value.pop();
+                    }
+                    doc.sections.entry(section_name.clone()).or_default().block = Some(RrBlock {
+                        kind: kind.trim().to_string(),
+                        value,
+                    });
+                    continue;
+                }
+                let row = parse_rr_row(trimmed)?;
+                doc.sections
+                    .entry(section_name.clone())
+                    .or_default()
+                    .rows
+                    .push(row);
+                continue;
+            }
+
+            let (key, value) = trimmed
+                .split_once(':')
+                .ok_or_else(|| format!("Expected field, got: {}", trimmed))?;
+            let value: String = serde_json::from_str(value.trim())
+                .map_err(|e| format!("Invalid field {}: {}", key.trim(), e))?;
+            doc.fields.insert(key.trim().to_string(), value);
+        }
+        Ok(doc)
+    }
+
+    fn take_required_field(&mut self, key: &str) -> Result<String, String> {
+        self.take_field(key)?
+            .ok_or_else(|| format!("Missing required field: {}", key))
+    }
+
+    fn take_field(&mut self, key: &str) -> Result<Option<String>, String> {
+        Ok(self.fields.remove(key))
+    }
+
+    fn take_rows(&mut self, section: &str) -> Result<Vec<KvRow>, String> {
+        Ok(self
+            .sections
+            .remove(section)
+            .map(|section| section.rows)
+            .unwrap_or_default())
+    }
+
+    fn take_text_block(&mut self, section: &str) -> Result<Option<String>, String> {
+        let section_name = section;
+        let Some(section) = self.sections.remove(section_name) else {
+            return Ok(None);
+        };
+        let Some(block) = section.block else {
+            return Ok(None);
+        };
+        if block.kind != "text" {
+            return Err(format!("Expected text block, got {}", block.kind));
+        }
+        Ok(Some(block.value))
+    }
+
+    fn take_json_block(&mut self, section: &str) -> Result<Option<serde_json::Value>, String> {
+        let section_name = section;
+        let Some(section) = self.sections.remove(section_name) else {
+            return Ok(None);
+        };
+        let Some(block) = section.block else {
+            return Ok(None);
+        };
+        if block.kind != "json" {
+            return Err(format!("Expected json block, got {}", block.kind));
+        }
+        serde_json::from_str(&block.value)
+            .map(Some)
+            .map_err(|e| format!("Invalid JSON block [{}]: {}", section_name, e))
+    }
+
+    fn reject_unknown(self) -> Result<(), String> {
+        if let Some(key) = self.fields.keys().next() {
+            return Err(format!("Unknown field: {}", key));
+        }
+        if let Some(key) = self.sections.keys().next() {
+            return Err(format!("Unknown section: {}", key));
+        }
+        Ok(())
+    }
+}
+
+fn parse_rr_row(line: &str) -> Result<KvRow, String> {
+    let (enabled, rest) = match line.chars().next() {
+        Some('+') => (true, &line[1..]),
+        Some('~') => (false, &line[1..]),
+        _ => return Err(format!("Expected row prefix + or ~, got: {}", line)),
+    };
+    let parts: Vec<&str> = rest.trim_start().splitn(3, '\t').collect();
+    if parts.len() != 3 {
+        return Err(format!("Expected tab-separated row: {}", line));
+    }
+    Ok(KvRow {
+        enabled,
+        key: serde_json::from_str(parts[0]).map_err(|e| format!("Invalid row key: {}", e))?,
+        value: serde_json::from_str(parts[1]).map_err(|e| format!("Invalid row value: {}", e))?,
+        description: serde_json::from_str(parts[2])
+            .map_err(|e| format!("Invalid row description: {}", e))?,
+    })
+}
+
+fn mask_request(request: &Request, rules: &MaskRules) -> Request {
     let mut request = request.clone();
     request.url = redact_url_query_and_fragment(&request.url);
-    request.query_params = mask_rows(&request.query_params);
-    request.path_params = mask_rows(&request.path_params);
-    request.headers = mask_rows(&request.headers);
-    request.cookies = mask_rows(&request.cookies);
-    request.body_ext = request.body_ext.map(mask_body_ext);
+    request.query_params = mask_rows(&request.query_params, rules);
+    request.path_params = mask_rows(&request.path_params, rules);
+    request.headers = mask_rows(&request.headers, rules);
+    request.cookies = mask_rows(&request.cookies, rules);
+    request.body_ext = request
+        .body_ext
+        .map(|body_ext| mask_body_ext(body_ext, rules));
     request.auth = mask_auth(&request.auth);
     request
 }
 
-fn mask_body_ext(body_ext: BodyExt) -> BodyExt {
+fn mask_body_ext(body_ext: BodyExt, rules: &MaskRules) -> BodyExt {
     match body_ext {
         BodyExt::FormUrlEncoded { fields } => BodyExt::FormUrlEncoded {
-            fields: mask_rows(&fields),
+            fields: mask_rows(&fields, rules),
         },
         BodyExt::MultipartForm { fields } => BodyExt::MultipartForm {
-            fields: mask_rows(&fields),
+            fields: mask_rows(&fields, rules),
         },
         BodyExt::GraphQL { variables } => BodyExt::GraphQL { variables },
     }
 }
 
-fn mask_rows(rows: &[KvRow]) -> Vec<KvRow> {
+fn mask_rows(rows: &[KvRow], rules: &MaskRules) -> Vec<KvRow> {
     rows.iter()
         .map(|row| {
             let mut row = row.clone();
-            if is_sensitive_key(&row.key) {
+            if should_mask_key(&row.key, rules) {
                 row.value = mask_secret_value(&row.value);
             }
             row
         })
         .collect()
+}
+
+fn should_mask_key(key: &str, rules: &MaskRules) -> bool {
+    let key = key.trim().to_ascii_lowercase();
+    if key.is_empty() {
+        return false;
+    }
+    if rules
+        .allow_patterns
+        .iter()
+        .any(|pattern| key_matches_pattern(&key, pattern))
+    {
+        return false;
+    }
+    is_sensitive_key(&key)
+        || rules
+            .mask_patterns
+            .iter()
+            .any(|pattern| key_matches_pattern(&key, pattern))
+}
+
+fn key_matches_pattern(normalized_key: &str, pattern: &str) -> bool {
+    let pattern = pattern.trim().to_ascii_lowercase();
+    if pattern.is_empty() {
+        return false;
+    }
+    normalized_key == pattern || normalized_key.contains(&pattern)
 }
 
 fn mask_auth(auth: &Auth) -> Auth {
@@ -428,6 +1020,34 @@ fn write_json_file<T: Serialize>(path: &Path, value: &T) -> io::Result<()> {
         .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
     file.write_all(b"\n")?;
     file.sync_all()
+}
+
+fn write_text_file(path: &Path, value: &str) -> io::Result<()> {
+    let mut file = fs::File::create(path)?;
+    file.write_all(value.as_bytes())?;
+    if !value.ends_with('\n') {
+        file.write_all(b"\n")?;
+    }
+    file.sync_all()
+}
+
+fn write_workspace_gitignore(root: &Path) -> Result<(), String> {
+    let path = root.join(".gitignore");
+    if path.exists() {
+        let meta = fs::symlink_metadata(&path)
+            .map_err(|e| format!("Inspect workspace .gitignore: {}", e))?;
+        if meta.file_type().is_symlink() {
+            return Err("Refusing to replace symlinked workspace .gitignore".to_string());
+        }
+        if !meta.is_file() {
+            return Err("Refusing to replace non-file workspace .gitignore".to_string());
+        }
+    }
+    write_text_file(
+        &path,
+        "# Rusty Requester local secret overlays\nsecrets/\n*.rrsecret\n",
+    )
+    .map_err(|e| format!("Write {}: {}", path.display(), e))
 }
 
 fn path_to_manifest_string(path: &Path) -> Result<String, String> {
@@ -504,6 +1124,7 @@ mod tests {
                 path_params: vec![KvRow::new("account_id", "acct_123")],
                 headers: vec![
                     KvRow::new("Content-Type", "application/json"),
+                    KvRow::new("platform", "android"),
                     KvRow::new("Authorization", "Bearer header-secret"),
                 ],
                 cookies: vec![KvRow::new("session_id", "cookie-secret")],
@@ -636,6 +1257,31 @@ mod tests {
     }
 
     #[test]
+    fn mask_rules_can_force_or_allow_keys() {
+        let root = temp_workspace("mask-rules");
+        export_workspace_to_dir(
+            &fixture_folders(),
+            &root,
+            ExportOptions {
+                secret_policy: SecretPolicy::Mask,
+                mask_rules: MaskRules {
+                    mask_patterns: vec!["platform".to_string()],
+                    allow_patterns: vec!["authorization".to_string()],
+                },
+            },
+        )
+        .unwrap();
+
+        let first_request =
+            read(root.join("requests/001-fixture-api-collection-1/001-create-widget-request-1.rr"));
+
+        assert!(first_request.contains("Bearer header-secret"));
+        assert!(!first_request.contains("\"android\""));
+        assert!(first_request.contains("\"*******\""));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn include_secrets_round_trips_without_data_loss_and_preserves_ids() {
         let root = temp_workspace("round-trip");
         let folders = fixture_folders();
@@ -645,6 +1291,7 @@ mod tests {
             &root,
             ExportOptions {
                 secret_policy: SecretPolicy::Include,
+                ..ExportOptions::default()
             },
         )
         .unwrap();
@@ -665,6 +1312,7 @@ mod tests {
             &root,
             ExportOptions {
                 secret_policy: SecretPolicy::Include,
+                ..ExportOptions::default()
             },
         )
         .unwrap();
@@ -673,7 +1321,9 @@ mod tests {
             root.join("requests/001-fixture-api-collection-1/001-create-widget-request-1.rr");
         let json_path =
             root.join("requests/001-fixture-api-collection-1/001-create-widget-request-1.json");
+        let request = rr_to_request(&read(&rr_path)).unwrap();
         fs::rename(&rr_path, &json_path).unwrap();
+        write_json_file(&json_path, &request).unwrap();
 
         let manifest_path = root.join(MANIFEST_FILE);
         let mut manifest: serde_json::Value = serde_json::from_str(&read(&manifest_path)).unwrap();
@@ -714,15 +1364,16 @@ mod tests {
             &root,
             ExportOptions {
                 secret_policy: SecretPolicy::Include,
+                ..ExportOptions::default()
             },
         )
         .unwrap();
 
         let path =
             root.join("requests/001-fixture-api-collection-1/001-create-widget-request-1.rr");
-        let mut request: Request = serde_json::from_str(&read(&path)).unwrap();
+        let mut request = rr_to_request(&read(&path)).unwrap();
         request.id = "different".into();
-        write_json_file(&path, &request).unwrap();
+        write_text_file(&path, &request_to_rr(&request).unwrap()).unwrap();
 
         let err = import_workspace_from_dir(&root).unwrap_err();
         assert!(err.contains("Request ID mismatch"), "{err}");
@@ -741,6 +1392,33 @@ mod tests {
 
         let err = import_workspace_from_dir(&root).unwrap_err();
         assert!(err.contains("must live under requests"), "{err}");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn native_rr_round_trips_body_with_default_block_delimiter() {
+        let mut folders = fixture_folders();
+        folders[0].requests[0].body = "line one\nRR_BLOCK\nline two".to_string();
+        let root = temp_workspace("delimiter");
+
+        export_workspace_to_dir(
+            &folders,
+            &root,
+            ExportOptions {
+                secret_policy: SecretPolicy::Include,
+                ..ExportOptions::default()
+            },
+        )
+        .unwrap();
+        let request_file =
+            root.join("requests/001-fixture-api-collection-1/001-create-widget-request-1.rr");
+        let exported = read(&request_file);
+
+        assert!(exported.contains("text <<RR_BLOCK_1"));
+        assert_eq!(
+            import_workspace_from_dir(&root).unwrap()[0].requests[0].body,
+            "line one\nRR_BLOCK\nline two"
+        );
         let _ = fs::remove_dir_all(root);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,6 +80,13 @@ pub(crate) enum UpdateCheckOutcome {
     Idle,
     Checking,
     NoUpdate,
+    Failed(String),
+}
+
+pub(crate) enum UpdateCheckMessage {
+    Available(String),
+    Current,
+    Failed(String),
 }
 
 /// In-memory snapshot of a request's last response so switching tabs
@@ -255,8 +262,7 @@ struct ApiClient {
     startup_warning: Option<String>,
     /// Background update-check receiver. Set on startup via
     /// `spawn_update_check`; drained on each `update()` frame.
-    /// `Some(version)` when a newer GitHub release is available.
-    update_check_rx: Option<std::sync::mpsc::Receiver<String>>,
+    update_check_rx: Option<std::sync::mpsc::Receiver<UpdateCheckMessage>>,
     /// Latest version string found by the update check, cached so the
     /// banner stays visible across frames. `None` = no update / not
     /// checked yet / current version is latest.
@@ -2238,25 +2244,31 @@ impl eframe::App for ApiClient {
         // user having to close the modal.
         if let Some(rx) = &self.update_check_rx {
             match rx.try_recv() {
-                Ok(new_version) => {
-                    self.update_available = Some(new_version);
-                    // Manual check now reflected via `update_available`;
-                    // reset the inline marker so we don't show "Checking"
-                    // alongside the available pill.
-                    if matches!(self.manual_update_check, UpdateCheckOutcome::Checking) {
-                        self.manual_update_check = UpdateCheckOutcome::Idle;
+                Ok(message) => {
+                    match message {
+                        UpdateCheckMessage::Available(new_version) => {
+                            self.update_available = Some(new_version);
+                            if matches!(self.manual_update_check, UpdateCheckOutcome::Checking) {
+                                self.manual_update_check = UpdateCheckOutcome::Idle;
+                            }
+                        }
+                        UpdateCheckMessage::Current => {
+                            if matches!(self.manual_update_check, UpdateCheckOutcome::Checking) {
+                                self.manual_update_check = UpdateCheckOutcome::NoUpdate;
+                            }
+                        }
+                        UpdateCheckMessage::Failed(reason) => {
+                            if matches!(self.manual_update_check, UpdateCheckOutcome::Checking) {
+                                self.manual_update_check = UpdateCheckOutcome::Failed(reason);
+                            }
+                        }
                     }
-                    // No auto-open: a modal on launch blocks users from
-                    // getting to work. The persistent sidebar pill is
-                    // unmissable but non-blocking — click it when ready.
                     self.update_check_rx = None;
                 }
                 Err(std::sync::mpsc::TryRecvError::Disconnected) => {
-                    // No message + sender dropped = no newer version
-                    // (`spawn_update_check` also swallows network errors
-                    // silently — treat as "no update found").
                     if matches!(self.manual_update_check, UpdateCheckOutcome::Checking) {
-                        self.manual_update_check = UpdateCheckOutcome::NoUpdate;
+                        self.manual_update_check =
+                            UpdateCheckOutcome::Failed("Update check stopped".to_string());
                     }
                     self.update_check_rx = None;
                 }
@@ -2773,7 +2785,7 @@ fn collect_flat_requests(
 /// no check at all).
 pub(crate) fn spawn_update_check(
     rt: &tokio::runtime::Runtime,
-) -> std::sync::mpsc::Receiver<String> {
+) -> std::sync::mpsc::Receiver<UpdateCheckMessage> {
     let (tx, rx) = std::sync::mpsc::channel();
     let current = env!("CARGO_PKG_VERSION").to_string();
     rt.spawn(async move {
@@ -2784,27 +2796,49 @@ pub(crate) fn spawn_update_check(
             .timeout(std::time::Duration::from_secs(5))
             .user_agent(format!("rusty-requester/{}", current))
             .build();
-        let Ok(client) = client else { return };
+        let Ok(client) = client else {
+            let _ = tx.send(UpdateCheckMessage::Failed(
+                "Could not create update client".to_string(),
+            ));
+            return;
+        };
         let resp = client
             .get("https://api.github.com/repos/chud-lori/rusty-requester/releases/latest")
             .header("Accept", "application/vnd.github+json")
             .send()
             .await;
-        let Ok(resp) = resp else { return };
+        let Ok(resp) = resp else {
+            let _ = tx.send(UpdateCheckMessage::Failed(
+                "Could not reach GitHub releases".to_string(),
+            ));
+            return;
+        };
         if !resp.status().is_success() {
+            let _ = tx.send(UpdateCheckMessage::Failed(format!(
+                "GitHub returned {}",
+                resp.status()
+            )));
             return;
         }
         let Ok(json) = resp.json::<serde_json::Value>().await else {
+            let _ = tx.send(UpdateCheckMessage::Failed(
+                "Could not parse GitHub release response".to_string(),
+            ));
             return;
         };
         let Some(tag) = json.get("tag_name").and_then(|v| v.as_str()) else {
+            let _ = tx.send(UpdateCheckMessage::Failed(
+                "GitHub response did not include a release tag".to_string(),
+            ));
             return;
         };
         // `tag_name` is `v0.13.0`; strip the `v` to compare with
         // `CARGO_PKG_VERSION`.
         let latest = tag.trim_start_matches('v');
         if is_newer_semver(latest, &current) {
-            let _ = tx.send(tag.to_string());
+            let _ = tx.send(UpdateCheckMessage::Available(tag.to_string()));
+        } else {
+            let _ = tx.send(UpdateCheckMessage::Current);
         }
     });
     rx

--- a/src/model.rs
+++ b/src/model.rs
@@ -439,6 +439,14 @@ pub struct SyncConfig {
     /// lossless local/private exports per operation.
     #[serde(default)]
     pub include_secrets_in_git_workspace: bool,
+    /// Case-insensitive key/name patterns that should be masked even when
+    /// Rusty Requester's built-in sensitive-key detector would not flag them.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub mask_key_patterns: String,
+    /// Case-insensitive key/name patterns that are safe to keep readable even
+    /// if their name matches a built-in sensitive-key heuristic.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub allow_key_patterns: String,
     /// Commit message used by the optional local Git push workflow.
     #[serde(default = "default_git_commit_message")]
     pub git_commit_message: String,
@@ -449,6 +457,8 @@ impl SyncConfig {
         self.git_workspace_dir.is_empty()
             && self.openapi_spec_path.is_empty()
             && !self.include_secrets_in_git_workspace
+            && self.mask_key_patterns.trim().is_empty()
+            && self.allow_key_patterns.trim().is_empty()
             && self.git_commit_message == default_git_commit_message()
     }
 }

--- a/src/sync/apply.rs
+++ b/src/sync/apply.rs
@@ -25,12 +25,17 @@ impl ApiClient {
     fn apply_sync_result(&mut self, result: Result<SyncApply, String>) {
         match result {
             Ok(SyncApply::Toast(message)) => self.show_toast(message),
-            Ok(SyncApply::ReplaceFolders { folders, message }) => {
+            Ok(SyncApply::ReplaceWorkspace {
+                folders,
+                environments,
+                message,
+            }) => {
                 if let Err(e) = backup::create_backup(&self.storage_path) {
                     self.show_toast(format!("Sync aborted: backup failed: {}", e));
                     return;
                 }
                 self.state.folders = folders;
+                self.state.environments = environments;
                 self.prune_stale_tabs();
                 self.save_state();
                 self.show_toast(message);
@@ -38,6 +43,7 @@ impl ApiClient {
             Ok(SyncApply::ReplaceCollection {
                 folder_id,
                 mut folder,
+                environments,
                 message,
             }) => {
                 if let Err(e) = backup::create_backup(&self.storage_path) {
@@ -46,7 +52,10 @@ impl ApiClient {
                 }
                 if let Some(existing) = find_folder_by_id_mut(&mut self.state.folders, &folder_id) {
                     folder.sync = existing.sync.clone();
-                    *existing = folder;
+                    *existing = *folder;
+                    if !environments.is_empty() {
+                        self.state.environments = environments;
+                    }
                     self.prune_stale_tabs();
                     self.save_state();
                     self.show_toast(message);

--- a/src/sync/job.rs
+++ b/src/sync/job.rs
@@ -1,4 +1,4 @@
-use crate::model::Folder;
+use crate::model::{Environment, Folder};
 
 pub(crate) struct InFlightSync {
     pub(crate) label: String,
@@ -7,13 +7,15 @@ pub(crate) struct InFlightSync {
 
 pub(crate) enum SyncApply {
     Toast(String),
-    ReplaceFolders {
+    ReplaceWorkspace {
         folders: Vec<Folder>,
+        environments: Vec<Environment>,
         message: String,
     },
     ReplaceCollection {
         folder_id: String,
-        folder: Folder,
+        folder: Box<Folder>,
+        environments: Vec<Environment>,
         message: String,
     },
     CollectionGitStatus {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -44,16 +44,22 @@ impl ApiClient {
         let root = PathBuf::from(root);
         let options = collection_export_options(&folder.sync);
         let include_secrets = folder.sync.include_secrets_in_git_workspace;
+        let environments = self.state.environments.clone();
         self.spawn_sync_job("Exporting collection workspace", move || {
-            let summary = io::git_workspace::export_workspace_to_dir(&[folder], &root, options)?;
+            let summary = io::git_workspace::export_workspace_with_environments_to_dir(
+                &[folder],
+                &environments,
+                &root,
+                options,
+            )?;
             let mode = if include_secrets {
                 "with secrets"
             } else {
                 "masked"
             };
             Ok(SyncApply::Toast(format!(
-                "Exported collection workspace {} ({} request file(s))",
-                mode, summary.request_files
+                "Exported collection workspace {} ({} request file(s), {} environment file(s))",
+                mode, summary.request_files, summary.environment_files
             )))
         });
     }
@@ -71,13 +77,14 @@ impl ApiClient {
         let root = PathBuf::from(root);
         let folder_id = folder_id.to_string();
         self.spawn_sync_job("Importing collection workspace", move || {
-            let mut folders = io::git_workspace::import_workspace_from_dir(&root)?;
-            if folders.len() != 1 {
+            let mut bundle = io::git_workspace::import_workspace_bundle_from_dir(&root)?;
+            if bundle.folders.len() != 1 {
                 return Err("Collection workspace must contain exactly one collection".to_string());
             }
             Ok(SyncApply::ReplaceCollection {
                 folder_id,
-                folder: folders.remove(0),
+                folder: Box::new(bundle.folders.remove(0)),
+                environments: bundle.environments,
                 message: "Imported collection workspace".to_string(),
             })
         });
@@ -89,13 +96,14 @@ impl ApiClient {
         };
         self.spawn_sync_job("Pulling collection remote", move || {
             git::run(&root, &["pull", "--ff-only"]).map_err(|e| e.to_string())?;
-            let mut folders = io::git_workspace::import_workspace_from_dir(&root)?;
-            if folders.len() != 1 {
+            let mut bundle = io::git_workspace::import_workspace_bundle_from_dir(&root)?;
+            if bundle.folders.len() != 1 {
                 return Err("Collection workspace must contain exactly one collection".to_string());
             }
             Ok(SyncApply::ReplaceCollection {
                 folder_id,
-                folder: folders.remove(0),
+                folder: Box::new(bundle.folders.remove(0)),
+                environments: bundle.environments,
                 message: "Pulled collection from Git remote".to_string(),
             })
         });
@@ -109,6 +117,7 @@ impl ApiClient {
             self.show_toast("Collection not found");
             return;
         };
+        let environments = self.state.environments.clone();
         let options = collection_export_options(&folder.sync);
         let message = folder.sync.git_commit_message.trim();
         let message = if message.is_empty() {
@@ -118,8 +127,17 @@ impl ApiClient {
         }
         .to_string();
         self.spawn_sync_job("Pushing collection remote", move || {
-            io::git_workspace::export_workspace_to_dir(&[folder], &root, options)?;
-            git::run(&root, &["add", "workspace.json", "requests"]).map_err(|e| e.to_string())?;
+            io::git_workspace::export_workspace_with_environments_to_dir(
+                &[folder],
+                &environments,
+                &root,
+                options,
+            )?;
+            git::run(
+                &root,
+                &["add", "workspace.json", "requests", "environments"],
+            )
+            .map_err(|e| e.to_string())?;
             match git::run(&root, &["commit", "-m", &message]) {
                 Ok(_) | Err(git::GitError::NothingToCommit) => {}
                 Err(e) => return Err(e.to_string()),
@@ -193,7 +211,8 @@ impl ApiClient {
             } else {
                 Ok(SyncApply::ReplaceCollection {
                     folder_id,
-                    folder: folders.remove(0),
+                    folder: Box::new(folders.remove(0)),
+                    environments: Vec::new(),
                     message: format!("Refreshed {} collection OpenAPI request(s)", updated),
                 })
             }
@@ -238,11 +257,16 @@ impl ApiClient {
         }
         let root = PathBuf::from(root);
         self.spawn_sync_job("Importing Git workspace", move || {
-            let folders = io::git_workspace::import_workspace_from_dir(&root)?;
-            let n = folders.len();
-            Ok(SyncApply::ReplaceFolders {
-                folders,
-                message: format!("Imported Git workspace ({} collection(s))", n),
+            let bundle = io::git_workspace::import_workspace_bundle_from_dir(&root)?;
+            let n = bundle.folders.len();
+            let envs = bundle.environments.len();
+            Ok(SyncApply::ReplaceWorkspace {
+                folders: bundle.folders,
+                environments: bundle.environments,
+                message: format!(
+                    "Imported Git workspace ({} collection(s), {} environment(s))",
+                    n, envs
+                ),
             })
         });
     }
@@ -260,17 +284,23 @@ impl ApiClient {
         let root = PathBuf::from(root);
         let options = self.git_workspace_export_options();
         let folders = self.state.folders.clone();
+        let environments = self.state.environments.clone();
         let include_secrets = self.state.sync.include_secrets_in_git_workspace;
         self.spawn_sync_job("Exporting Git workspace", move || {
-            let summary = io::git_workspace::export_workspace_to_dir(&folders, &root, options)?;
+            let summary = io::git_workspace::export_workspace_with_environments_to_dir(
+                &folders,
+                &environments,
+                &root,
+                options,
+            )?;
             let mode = if include_secrets {
                 "with secrets"
             } else {
                 "masked"
             };
             Ok(SyncApply::Toast(format!(
-                "Exported Git workspace {} ({} request file(s))",
-                mode, summary.request_files
+                "Exported Git workspace {} ({} request file(s), {} environment file(s))",
+                mode, summary.request_files, summary.environment_files
             )))
         });
     }
@@ -331,11 +361,16 @@ impl ApiClient {
         };
         self.spawn_sync_job("Pulling GitHub workspace", move || {
             git::run(&root, &["pull", "--ff-only"]).map_err(|e| e.to_string())?;
-            let folders = io::git_workspace::import_workspace_from_dir(&root)?;
-            let n = folders.len();
-            Ok(SyncApply::ReplaceFolders {
-                folders,
-                message: format!("Pulled Git workspace ({} collection(s))", n),
+            let bundle = io::git_workspace::import_workspace_bundle_from_dir(&root)?;
+            let n = bundle.folders.len();
+            let envs = bundle.environments.len();
+            Ok(SyncApply::ReplaceWorkspace {
+                folders: bundle.folders,
+                environments: bundle.environments,
+                message: format!(
+                    "Pulled Git workspace ({} collection(s), {} environment(s))",
+                    n, envs
+                ),
             })
         });
     }
@@ -349,6 +384,7 @@ impl ApiClient {
             return;
         };
         let folders = self.state.folders.clone();
+        let environments = self.state.environments.clone();
         let options = self.git_workspace_export_options();
         let message = self.state.sync.git_commit_message.trim();
         let message = if message.is_empty() {
@@ -358,8 +394,17 @@ impl ApiClient {
         }
         .to_string();
         self.spawn_sync_job("Pushing GitHub workspace", move || {
-            io::git_workspace::export_workspace_to_dir(&folders, &root, options)?;
-            git::run(&root, &["add", "workspace.json", "requests"]).map_err(|e| e.to_string())?;
+            io::git_workspace::export_workspace_with_environments_to_dir(
+                &folders,
+                &environments,
+                &root,
+                options,
+            )?;
+            git::run(
+                &root,
+                &["add", "workspace.json", "requests", "environments"],
+            )
+            .map_err(|e| e.to_string())?;
             match git::run(&root, &["commit", "-m", &message]) {
                 Ok(_) | Err(git::GitError::NothingToCommit) => {}
                 Err(e) => return Err(e.to_string()),
@@ -378,6 +423,7 @@ impl ApiClient {
             } else {
                 io::git_workspace::SecretPolicy::Mask
             },
+            mask_rules: mask_rules_from_sync(&self.state.sync),
         }
     }
 
@@ -432,5 +478,22 @@ fn collection_export_options(sync: &crate::model::SyncConfig) -> io::git_workspa
         } else {
             io::git_workspace::SecretPolicy::Mask
         },
+        mask_rules: mask_rules_from_sync(sync),
     }
+}
+
+fn mask_rules_from_sync(sync: &crate::model::SyncConfig) -> io::git_workspace::MaskRules {
+    io::git_workspace::MaskRules {
+        mask_patterns: split_key_patterns(&sync.mask_key_patterns),
+        allow_patterns: split_key_patterns(&sync.allow_key_patterns),
+    }
+}
+
+fn split_key_patterns(input: &str) -> Vec<String> {
+    input
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(str::to_string)
+        .collect()
 }

--- a/src/ui/collection_settings.rs
+++ b/src/ui/collection_settings.rs
@@ -64,7 +64,7 @@ impl ApiClient {
                 ui.label(
                     egui::RichText::new(
                         "Exports this collection as reviewable workspace files. Requests are \
-                         saved as pretty JSON with the .rr extension for readable pull requests.",
+                         saved as compact .rr text files for readable pull requests.",
                     )
                     .size(10.5)
                     .color(muted()),
@@ -116,6 +116,45 @@ impl ApiClient {
                     .size(10.5)
                     .color(muted()),
                 );
+
+                ui.add_space(8.0);
+                ui.label(
+                    egui::RichText::new("Mask rules")
+                        .size(12.0)
+                        .strong()
+                        .color(text()),
+                );
+                ui.label(
+                    egui::RichText::new(
+                        "Comma-separated key/header/env-name patterns. Keep readable wins over \
+                         built-in and custom mask rules.",
+                    )
+                    .size(10.5)
+                    .color(muted()),
+                );
+                ui.add_space(5.0);
+                ui.horizontal(|ui| {
+                    ui.label(egui::RichText::new("Always mask").size(11.0).color(muted()));
+                    let response = ui.add(
+                        egui::TextEdit::singleline(&mut sync.mask_key_patterns)
+                            .hint_text(hint("x-api-key, token, authorization"))
+                            .desired_width(ui.available_width()),
+                    );
+                    changed |= response.changed();
+                });
+                ui.horizontal(|ui| {
+                    ui.label(
+                        egui::RichText::new("Keep readable")
+                            .size(11.0)
+                            .color(muted()),
+                    );
+                    let response = ui.add(
+                        egui::TextEdit::singleline(&mut sync.allow_key_patterns)
+                            .hint_text(hint("platform, env, app-version"))
+                            .desired_width(ui.available_width()),
+                    );
+                    changed |= response.changed();
+                });
 
                 ui.add_space(8.0);
                 ui.horizontal(|ui| {

--- a/src/ui/modals/update.rs
+++ b/src/ui/modals/update.rs
@@ -329,59 +329,60 @@ impl ApiClient {
         if !self.updating_in_progress {
             return;
         }
+        ctx.request_repaint_after(std::time::Duration::from_millis(33));
         let log_path = update_log_path();
         let tail = self.update_log_tail.clone();
+        let phase = infer_update_phase(&tail);
         let mut view_log = false;
 
         egui::Window::new("Updating rusty-requester…")
             .collapsible(false)
             .resizable(false)
             .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-            .fixed_size([620.0, 360.0])
+            .fixed_size([500.0, 0.0])
             .show(ctx, |ui| {
-                ui.add_space(4.0);
+                ui.add_space(6.0);
+                render_update_progress_strip(ui, ctx.input(|i| i.time));
+                ui.add_space(14.0);
+                render_update_steps(ui, phase);
+                ui.add_space(12.0);
                 ui.label(
                     egui::RichText::new(
-                        "The installer is running in the background. The app will \
-                         quit and relaunch automatically when it finishes.",
+                        "The installer is running in the background. The app may close and \
+                         relaunch automatically while the binary is replaced.",
                     )
                     .color(muted())
                     .size(11.5),
                 );
                 ui.add_space(8.0);
-                ui.label(
-                    egui::RichText::new(format!("Log: {}", log_path.display()))
-                        .color(muted())
-                        .size(10.5)
-                        .monospace(),
-                );
-                ui.add_space(6.0);
                 egui::Frame::none()
                     .fill(panel_dark())
                     .stroke(egui::Stroke::new(1.0, border()))
                     .rounding(egui::Rounding::same(6.0))
-                    .inner_margin(egui::Margin::symmetric(10.0, 8.0))
+                    .inner_margin(egui::Margin::symmetric(10.0, 9.0))
                     .show(ui, |ui| {
-                        egui::ScrollArea::vertical()
-                            .stick_to_bottom(true)
-                            .max_height(240.0)
-                            .auto_shrink([false; 2])
-                            .show(ui, |ui| {
-                                if tail.is_empty() {
-                                    ui.label(
-                                        egui::RichText::new("Starting installer…")
-                                            .color(muted())
-                                            .size(11.0)
-                                            .italics(),
-                                    );
-                                } else {
-                                    ui.label(
-                                        egui::RichText::new(&tail)
-                                            .color(text())
-                                            .font(egui::FontId::monospace(10.5)),
-                                    );
-                                }
-                            });
+                        ui.set_width(ui.available_width());
+                        ui.label(
+                            egui::RichText::new(phase.label())
+                                .color(text())
+                                .size(12.0)
+                                .strong(),
+                        );
+                        ui.add_space(3.0);
+                        ui.label(
+                            egui::RichText::new(
+                                latest_log_line(&tail).unwrap_or("Starting installer..."),
+                            )
+                            .color(muted())
+                            .font(egui::FontId::monospace(10.5)),
+                        );
+                        ui.add_space(4.0);
+                        ui.label(
+                            egui::RichText::new(format!("Log: {}", log_path.display()))
+                                .color(muted())
+                                .size(10.0)
+                                .monospace(),
+                        );
                     });
                 ui.add_space(8.0);
                 ui.horizontal(|ui| {
@@ -516,4 +517,106 @@ impl ApiClient {
             self.post_update_notice = None;
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum UpdatePhase {
+    Download,
+    Install,
+    Relaunch,
+}
+
+impl UpdatePhase {
+    fn label(self) -> &'static str {
+        match self {
+            UpdatePhase::Download => "Downloading release",
+            UpdatePhase::Install => "Installing update",
+            UpdatePhase::Relaunch => "Preparing relaunch",
+        }
+    }
+}
+
+fn infer_update_phase(tail: &str) -> UpdatePhase {
+    let lower = tail.to_ascii_lowercase();
+    if lower.contains("relaunch")
+        || lower.contains("launch services")
+        || lower.contains("register")
+        || lower.contains("starting")
+    {
+        UpdatePhase::Relaunch
+    } else if lower.contains("copy")
+        || lower.contains("install")
+        || lower.contains("quarantine")
+        || lower.contains("chmod")
+    {
+        UpdatePhase::Install
+    } else {
+        UpdatePhase::Download
+    }
+}
+
+fn render_update_steps(ui: &mut egui::Ui, phase: UpdatePhase) {
+    ui.horizontal(|ui| {
+        for (index, (step, label)) in [
+            (UpdatePhase::Download, "Download"),
+            (UpdatePhase::Install, "Install"),
+            (UpdatePhase::Relaunch, "Relaunch"),
+        ]
+        .iter()
+        .enumerate()
+        {
+            let active = *step <= phase;
+            let color = if active { accent() } else { muted() };
+            ui.label(
+                egui::RichText::new(format!("{} {}", egui_phosphor::regular::CIRCLE, label))
+                    .color(color)
+                    .size(11.0),
+            );
+            if index < 2 {
+                let (rect, _) = ui.allocate_exact_size(egui::vec2(44.0, 1.0), egui::Sense::hover());
+                ui.painter().rect_filled(
+                    rect,
+                    egui::Rounding::same(1.0),
+                    if active {
+                        with_alpha(accent(), 140)
+                    } else {
+                        with_alpha(border(), 120)
+                    },
+                );
+            }
+        }
+    });
+}
+
+fn render_update_progress_strip(ui: &mut egui::Ui, time: f64) {
+    let width = ui.available_width().max(220.0);
+    let (rect, _) = ui.allocate_exact_size(egui::vec2(width, 8.0), egui::Sense::hover());
+    ui.painter()
+        .rect_filled(rect, egui::Rounding::same(4.0), elevated());
+    ui.painter().rect_stroke(
+        rect,
+        egui::Rounding::same(4.0),
+        egui::Stroke::new(1.0, border()),
+    );
+
+    let segment_width = rect.width() * 0.32;
+    let travel = rect.width() + segment_width;
+    let x = rect.left() - segment_width + ((time * 150.0) as f32 % travel);
+    let segment = egui::Rect::from_min_size(
+        egui::pos2(x, rect.top()),
+        egui::vec2(segment_width, rect.height()),
+    )
+    .intersect(rect);
+    ui.painter().rect_filled(
+        segment,
+        egui::Rounding::same(4.0),
+        with_alpha(accent(), 210),
+    );
+}
+
+fn latest_log_line(tail: &str) -> Option<&str> {
+    tail.lines()
+        .rev()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
 }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -161,6 +161,8 @@ impl ApiClient {
                 "available"
             } else if matches!(self.manual_update_check, UpdateCheckOutcome::Checking) {
                 "checking"
+            } else if matches!(self.manual_update_check, UpdateCheckOutcome::Failed(_)) {
+                "failed"
             } else if matches!(self.manual_update_check, UpdateCheckOutcome::NoUpdate) {
                 "uptodate"
             } else {
@@ -188,6 +190,22 @@ impl ApiClient {
                         ))
                         .size(11.0)
                         .color(muted()),
+                    );
+                }
+                "failed" => {
+                    let reason = match &self.manual_update_check {
+                        UpdateCheckOutcome::Failed(reason) => reason.as_str(),
+                        _ => "Update check failed",
+                    };
+                    ui.add_space(8.0);
+                    ui.label(
+                        egui::RichText::new(format!(
+                            "{}  Could not check for updates: {}",
+                            egui_phosphor::regular::WARNING,
+                            reason
+                        ))
+                        .size(11.0)
+                        .color(C_ORANGE),
                     );
                 }
                 "available" => {


### PR DESCRIPTION
## Summary
- replace plain JSON .rr request exports with a compact native Rusty Requester text format
- add environment .rrenv files, workspace .gitignore for local secret overlays, and legacy JSON request import compatibility
- add collection-level mask/allow key patterns for Git exports
- fix manual update checks so network/API failures do not report a false latest-version state
- refresh the in-app update progress UI and restore mobile navigation in the docs page

## Tests
- cargo fmt --check
- cargo test -q
- cargo clippy --all-targets -- -D warnings
- git diff --check