### PR TITLE
Fix collection settings layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Fixed
+- **Collection Settings layout.** The collection settings modal now uses a
+  wider two-column layout with a left status rail and grouped right-side
+  controls, making Git, masking, folder export, and OpenAPI options easier to
+  scan.
+
 ## [0.27.0] — 2026-06-18
 
 ### Added

--- a/src/ui/collection_settings.rs
+++ b/src/ui/collection_settings.rs
@@ -32,246 +32,255 @@ impl ApiClient {
 
         egui::Window::new("Collection Settings")
             .collapsible(false)
-            .resizable(false)
-            .default_width(660.0)
+            .resizable(true)
+            .default_width(860.0)
+            .default_height(620.0)
             .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
             .open(&mut open)
             .show(ctx, |ui| {
-                ui.set_min_width(620.0);
-                ui.label(
-                    egui::RichText::new(&folder.name)
-                        .size(16.0)
-                        .strong()
-                        .color(text()),
-                );
-                ui.label(
-                    egui::RichText::new(
-                        "Link this collection to a local folder or Git repository. Private \
-                         GitHub/GitLab/Bitbucket repos work through your existing local Git \
-                         credentials; Rusty Requester does not store Git provider tokens.",
-                    )
-                    .size(10.5)
-                    .color(muted()),
-                );
-                ui.add_space(12.0);
-
-                ui.label(
-                    egui::RichText::new("Collection directory")
-                        .size(12.0)
-                        .strong()
-                        .color(text()),
-                );
-                ui.label(
-                    egui::RichText::new(
-                        "Exports this collection as reviewable workspace files. Requests are \
-                         saved as compact .rr text files for readable pull requests.",
-                    )
-                    .size(10.5)
-                    .color(muted()),
-                );
-                ui.add_space(6.0);
-                ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new("Directory").size(11.0).color(muted()));
-                    let response = ui.add(
-                        egui::TextEdit::singleline(&mut sync.git_workspace_dir)
-                            .hint_text(hint("/path/to/collection-repo"))
-                            .desired_width(ui.available_width() - 96.0),
-                    );
-                    changed |= response.changed();
-                    if ui.button("Choose...").clicked() {
-                        choose_git_dir = true;
-                    }
-                });
-
                 let git_ready = !sync.git_workspace_dir.trim().is_empty();
                 let is_git_repo = git_ready
                     && std::path::Path::new(sync.git_workspace_dir.trim())
                         .join(".git")
                         .is_dir();
-                if git_ready && !is_git_repo {
-                    ui.label(
-                        egui::RichText::new(
-                            "Remote pull/push needs the repository root containing .git.",
-                        )
-                        .size(10.5)
-                        .color(C_ORANGE),
-                    );
-                }
+                let busy = self.sync_in_flight.is_some();
+                let openapi_ready = !sync.openapi_spec_path.trim().is_empty();
 
-                ui.add_space(6.0);
-                if ui
-                    .checkbox(
-                        &mut sync.include_secrets_in_git_workspace,
-                        "Include secrets in collection exports",
-                    )
-                    .changed()
-                {
-                    changed = true;
-                }
-                ui.label(
-                    egui::RichText::new(
-                        "Keep this off for shared repos. A private repo is access control, not \
-                         encryption or a guarantee that secrets are safe to commit.",
-                    )
-                    .size(10.5)
-                    .color(muted()),
-                );
+                ui.set_min_size(egui::vec2(780.0, 540.0));
+                ui.horizontal(|ui| {
+                    collection_settings_nav(ui, &folder.name, git_ready, is_git_repo, openapi_ready);
 
-                ui.add_space(8.0);
-                ui.label(
-                    egui::RichText::new("Mask rules")
-                        .size(12.0)
-                        .strong()
-                        .color(text()),
-                );
-                ui.label(
-                    egui::RichText::new(
-                        "Comma-separated key/header/env-name patterns. Keep readable wins over \
-                         built-in and custom mask rules.",
-                    )
-                    .size(10.5)
-                    .color(muted()),
-                );
-                ui.add_space(5.0);
-                ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new("Always mask").size(11.0).color(muted()));
-                    let response = ui.add(
-                        egui::TextEdit::singleline(&mut sync.mask_key_patterns)
-                            .hint_text(hint("x-api-key, token, authorization"))
-                            .desired_width(ui.available_width()),
-                    );
-                    changed |= response.changed();
-                });
-                ui.horizontal(|ui| {
-                    ui.label(
-                        egui::RichText::new("Keep readable")
-                            .size(11.0)
-                            .color(muted()),
-                    );
-                    let response = ui.add(
-                        egui::TextEdit::singleline(&mut sync.allow_key_patterns)
-                            .hint_text(hint("platform, env, app-version"))
-                            .desired_width(ui.available_width()),
-                    );
-                    changed |= response.changed();
-                });
+                    ui.separator();
 
-                ui.add_space(8.0);
-                ui.horizontal(|ui| {
-                    let busy = self.sync_in_flight.is_some();
-                    if ui
-                        .add_enabled(git_ready && !busy, egui::Button::new("Import from folder"))
-                        .clicked()
-                    {
-                        import_workspace = true;
-                    }
-                    if ui
-                        .add_enabled(git_ready && !busy, egui::Button::new("Export to folder"))
-                        .clicked()
-                    {
-                        export_workspace = true;
-                    }
-                });
-
-                ui.add_space(12.0);
-                ui.label(
-                    egui::RichText::new("Git remote")
-                        .size(12.0)
-                        .strong()
-                        .color(text()),
-                );
-                ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new("Commit").size(11.0).color(muted()));
-                    let response = ui.add(
-                        egui::TextEdit::singleline(&mut sync.git_commit_message)
-                            .hint_text(hint("Sync Rusty Requester collection"))
-                            .desired_width(ui.available_width()),
-                    );
-                    changed |= response.changed();
-                });
-                ui.add_space(6.0);
-                ui.horizontal(|ui| {
-                    let busy = self.sync_in_flight.is_some();
-                    if ui
-                        .add_enabled(is_git_repo && !busy, egui::Button::new("Refresh changes"))
-                        .clicked()
-                    {
-                        refresh_git_status = true;
-                    }
-                    if ui
-                        .add_enabled(is_git_repo && !busy, egui::Button::new("Pull from remote"))
-                        .clicked()
-                    {
-                        pull_remote = true;
-                    }
-                    if ui
-                        .add_enabled(is_git_repo && !busy, egui::Button::new("Commit and push"))
-                        .clicked()
-                    {
-                        push_remote = true;
-                    }
-                });
-                if !self.collection_git_status.is_empty() {
-                    ui.add_space(8.0);
-                    egui::Frame::none()
-                        .fill(elevated())
-                        .stroke(egui::Stroke::new(1.0, border()))
-                        .rounding(egui::Rounding::same(6.0))
-                        .inner_margin(egui::Margin::symmetric(10.0, 8.0))
+                    egui::ScrollArea::vertical()
+                        .id_salt("collection_settings_scroll")
+                        .auto_shrink([false, false])
                         .show(ui, |ui| {
-                            ui.set_max_height(120.0);
-                            egui::ScrollArea::vertical()
-                                .max_height(120.0)
-                                .show(ui, |ui| {
-                                    ui.monospace(&self.collection_git_status);
+                            ui.set_min_width(560.0);
+
+                            setting_card(ui, "Collection directory", "Reviewable files", |ui| {
+                                ui.label(
+                                    egui::RichText::new(
+                                        "Export this collection into a folder or repository as \
+                                         compact .rr files. The folder path is also used for Git \
+                                         pull/push actions below.",
+                                    )
+                                    .size(10.5)
+                                    .color(muted()),
+                                );
+                                ui.add_space(8.0);
+                                field_row(ui, "Directory", |ui| {
+                                    let response = ui.add(
+                                        egui::TextEdit::singleline(&mut sync.git_workspace_dir)
+                                            .hint_text(hint("/path/to/collection-repo"))
+                                            .desired_width(ui.available_width() - 106.0),
+                                    );
+                                    changed |= response.changed();
+                                    if ui.button("Choose...").clicked() {
+                                        choose_git_dir = true;
+                                    }
                                 });
+                                if git_ready && !is_git_repo {
+                                    ui.add_space(6.0);
+                                    status_note(
+                                        ui,
+                                        "Remote pull/push needs the repository root containing .git.",
+                                        C_ORANGE,
+                                    );
+                                }
+                                ui.add_space(10.0);
+                                ui.horizontal_wrapped(|ui| {
+                                    if ui
+                                        .add_enabled(
+                                            git_ready && !busy,
+                                            egui::Button::new("Import from folder"),
+                                        )
+                                        .clicked()
+                                    {
+                                        import_workspace = true;
+                                    }
+                                    if ui
+                                        .add_enabled(
+                                            git_ready && !busy,
+                                            egui::Button::new("Export to folder"),
+                                        )
+                                        .clicked()
+                                    {
+                                        export_workspace = true;
+                                    }
+                                });
+                            });
+
+                            ui.add_space(10.0);
+                            setting_card(ui, "Secrets and review rules", "Export safety", |ui| {
+                                if ui
+                                    .checkbox(
+                                        &mut sync.include_secrets_in_git_workspace,
+                                        "Include secrets in collection exports",
+                                    )
+                                    .changed()
+                                {
+                                    changed = true;
+                                }
+                                ui.label(
+                                    egui::RichText::new(
+                                        "Keep this off for shared repos. A private repo is access \
+                                         control, not encryption.",
+                                    )
+                                    .size(10.5)
+                                    .color(muted()),
+                                );
+                                ui.add_space(10.0);
+                                ui.label(
+                                    egui::RichText::new("Mask rules")
+                                        .size(11.0)
+                                        .strong()
+                                        .color(text()),
+                                );
+                                ui.label(
+                                    egui::RichText::new(
+                                        "Comma-separated key/header/env-name patterns. Keep readable \
+                                         wins over built-in and custom mask rules.",
+                                    )
+                                    .size(10.5)
+                                    .color(muted()),
+                                );
+                                ui.add_space(8.0);
+                                field_row(ui, "Always mask", |ui| {
+                                    let response = ui.add(
+                                        egui::TextEdit::singleline(&mut sync.mask_key_patterns)
+                                            .hint_text(hint("x-api-key, token, authorization"))
+                                            .desired_width(ui.available_width()),
+                                    );
+                                    changed |= response.changed();
+                                });
+                                ui.add_space(6.0);
+                                field_row(ui, "Keep readable", |ui| {
+                                    let response = ui.add(
+                                        egui::TextEdit::singleline(&mut sync.allow_key_patterns)
+                                            .hint_text(hint("platform, env, app-version"))
+                                            .desired_width(ui.available_width()),
+                                    );
+                                    changed |= response.changed();
+                                });
+                            });
+
+                            ui.add_space(10.0);
+                            setting_card(ui, "Git remote", "Pull and push", |ui| {
+                                ui.label(
+                                    egui::RichText::new(
+                                        "Uses your local Git credentials. Private GitHub, GitLab, and \
+                                         Bitbucket repositories work when the repository is already \
+                                         authenticated on this machine.",
+                                    )
+                                    .size(10.5)
+                                    .color(muted()),
+                                );
+                                ui.add_space(8.0);
+                                field_row(ui, "Commit", |ui| {
+                                    let response = ui.add(
+                                        egui::TextEdit::singleline(&mut sync.git_commit_message)
+                                            .hint_text(hint("Sync Rusty Requester collection"))
+                                            .desired_width(ui.available_width()),
+                                    );
+                                    changed |= response.changed();
+                                });
+                                ui.add_space(10.0);
+                                ui.horizontal_wrapped(|ui| {
+                                    if ui
+                                        .add_enabled(
+                                            is_git_repo && !busy,
+                                            egui::Button::new("Refresh changes"),
+                                        )
+                                        .clicked()
+                                    {
+                                        refresh_git_status = true;
+                                    }
+                                    if ui
+                                        .add_enabled(
+                                            is_git_repo && !busy,
+                                            egui::Button::new("Pull from remote"),
+                                        )
+                                        .clicked()
+                                    {
+                                        pull_remote = true;
+                                    }
+                                    if ui
+                                        .add_enabled(
+                                            is_git_repo && !busy,
+                                            egui::Button::new("Commit and push"),
+                                        )
+                                        .clicked()
+                                    {
+                                        push_remote = true;
+                                    }
+                                });
+                                if !self.collection_git_status.is_empty() {
+                                    ui.add_space(8.0);
+                                    egui::Frame::none()
+                                        .fill(elevated())
+                                        .stroke(egui::Stroke::new(1.0, border()))
+                                        .rounding(egui::Rounding::same(6.0))
+                                        .inner_margin(egui::Margin::symmetric(10.0, 8.0))
+                                        .show(ui, |ui| {
+                                            egui::ScrollArea::vertical()
+                                                .max_height(110.0)
+                                                .show(ui, |ui| {
+                                                    ui.monospace(&self.collection_git_status);
+                                                });
+                                        });
+                                }
+                            });
+
+                            ui.add_space(10.0);
+                            setting_card(ui, "OpenAPI refresh", "Regenerate requests", |ui| {
+                                field_row(ui, "Spec file", |ui| {
+                                    let response = ui.add(
+                                        egui::TextEdit::singleline(&mut sync.openapi_spec_path)
+                                            .hint_text(hint("/path/to/openapi.yaml"))
+                                            .desired_width(ui.available_width() - 106.0),
+                                    );
+                                    changed |= response.changed();
+                                    if ui.button("Choose...").clicked() {
+                                        choose_openapi_file = true;
+                                    }
+                                });
+                                ui.add_space(10.0);
+                                if ui
+                                    .add_enabled(
+                                        openapi_ready && !busy,
+                                        egui::Button::new("Refresh collection from OpenAPI"),
+                                    )
+                                    .clicked()
+                                {
+                                    refresh_openapi = true;
+                                }
+                            });
+
+                            if let Some(sync) = &self.sync_in_flight {
+                                ui.add_space(12.0);
+                                egui::Frame::none()
+                                    .fill(elevated())
+                                    .stroke(egui::Stroke::new(1.0, border()))
+                                    .rounding(egui::Rounding::same(6.0))
+                                    .inner_margin(egui::Margin::symmetric(10.0, 8.0))
+                                    .show(ui, |ui| {
+                                        ui.horizontal(|ui| {
+                                            ui.spinner();
+                                            ui.label(
+                                                egui::RichText::new(&sync.label)
+                                                    .size(11.0)
+                                                    .color(muted()),
+                                            );
+                                        });
+                                    });
+                            }
                         });
-                }
-
-                ui.add_space(14.0);
-                ui.separator();
-                ui.add_space(10.0);
-
-                ui.label(
-                    egui::RichText::new("OpenAPI refresh")
-                        .size(12.0)
-                        .strong()
-                        .color(text()),
-                );
-                ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new("Spec file").size(11.0).color(muted()));
-                    let response = ui.add(
-                        egui::TextEdit::singleline(&mut sync.openapi_spec_path)
-                            .hint_text(hint("/path/to/openapi.yaml"))
-                            .desired_width(ui.available_width() - 96.0),
-                    );
-                    changed |= response.changed();
-                    if ui.button("Choose...").clicked() {
-                        choose_openapi_file = true;
-                    }
                 });
-                ui.add_space(6.0);
-                if ui
-                    .add_enabled(
-                        !sync.openapi_spec_path.trim().is_empty() && self.sync_in_flight.is_none(),
-                        egui::Button::new("Refresh collection from OpenAPI"),
-                    )
-                    .clicked()
-                {
-                    refresh_openapi = true;
-                }
 
-                if let Some(sync) = &self.sync_in_flight {
-                    ui.add_space(12.0);
-                    ui.horizontal(|ui| {
-                        ui.spinner();
-                        ui.label(egui::RichText::new(&sync.label).size(11.0).color(muted()));
-                    });
-                }
-
-                ui.add_space(14.0);
+                ui.add_space(8.0);
                 ui.separator();
-                ui.add_space(6.0);
+                ui.add_space(4.0);
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     if ui.button("Close").clicked() {
                         self.show_collection_settings_modal = false;
@@ -312,4 +321,126 @@ impl ApiClient {
             self.refresh_collection_openapi_from_config(&folder_id);
         }
     }
+}
+
+fn collection_settings_nav(
+    ui: &mut egui::Ui,
+    collection_name: &str,
+    git_ready: bool,
+    is_git_repo: bool,
+    openapi_ready: bool,
+) {
+    ui.vertical(|ui| {
+        ui.set_width(190.0);
+        ui.label(
+            egui::RichText::new(collection_name)
+                .size(18.0)
+                .strong()
+                .color(text()),
+        );
+        ui.label(
+            egui::RichText::new("Collection settings")
+                .size(10.5)
+                .color(muted()),
+        );
+        ui.add_space(14.0);
+
+        nav_status(ui, "Directory", git_ready, "Folder selected", "Not linked");
+        nav_status(
+            ui,
+            "Secrets",
+            true,
+            "Masked by default",
+            "Masked by default",
+        );
+        nav_status(
+            ui,
+            "Git remote",
+            is_git_repo,
+            "Git repo ready",
+            "Needs .git folder",
+        );
+        nav_status(
+            ui,
+            "OpenAPI",
+            openapi_ready,
+            "Spec selected",
+            "No spec selected",
+        );
+
+        ui.add_space(14.0);
+        egui::Frame::none()
+            .fill(with_alpha(accent(), 18))
+            .stroke(egui::Stroke::new(1.0, with_alpha(accent(), 70)))
+            .rounding(egui::Rounding::same(6.0))
+            .inner_margin(egui::Margin::symmetric(10.0, 8.0))
+            .show(ui, |ui| {
+                ui.label(
+                    egui::RichText::new("Git providers are not stored here.")
+                        .size(10.5)
+                        .strong()
+                        .color(text()),
+                );
+                ui.label(
+                    egui::RichText::new("Remote access uses your local Git credentials.")
+                        .size(10.0)
+                        .color(muted()),
+                );
+            });
+    });
+}
+
+fn nav_status(ui: &mut egui::Ui, title: &str, ready: bool, ready_text: &str, empty_text: &str) {
+    let color = if ready { C_GREEN } else { muted() };
+    ui.add_space(2.0);
+    ui.label(egui::RichText::new(title).size(11.5).strong().color(text()));
+    ui.label(
+        egui::RichText::new(if ready { ready_text } else { empty_text })
+            .size(10.0)
+            .color(color),
+    );
+    ui.add_space(8.0);
+}
+
+fn setting_card(
+    ui: &mut egui::Ui,
+    title: &str,
+    eyebrow: &str,
+    add_contents: impl FnOnce(&mut egui::Ui),
+) {
+    egui::Frame::none()
+        .fill(panel_dark())
+        .stroke(egui::Stroke::new(1.0, border()))
+        .rounding(egui::Rounding::same(8.0))
+        .inner_margin(egui::Margin::symmetric(14.0, 12.0))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.label(egui::RichText::new(title).size(14.0).strong().color(text()));
+                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                    ui.label(
+                        egui::RichText::new(eyebrow)
+                            .size(10.0)
+                            .strong()
+                            .color(muted()),
+                    );
+                });
+            });
+            ui.add_space(8.0);
+            add_contents(ui);
+        });
+}
+
+fn field_row(ui: &mut egui::Ui, label: &str, add_field: impl FnOnce(&mut egui::Ui)) {
+    ui.horizontal(|ui| {
+        ui.set_min_height(30.0);
+        ui.add_sized(
+            egui::vec2(96.0, 24.0),
+            egui::Label::new(egui::RichText::new(label).size(11.0).color(muted())),
+        );
+        add_field(ui);
+    });
+}
+
+fn status_note(ui: &mut egui::Ui, text_value: &str, color: egui::Color32) {
+    ui.label(egui::RichText::new(text_value).size(10.5).color(color));
 }


### PR DESCRIPTION
## Summary
- redesign Collection Settings into a two-column settings surface
- group folder export, secret masking, Git remote, and OpenAPI controls into clear sections
- add changelog entry for the patch release

## Test
- cargo fmt --check
- cargo test -q
- cargo clippy --all-targets -- -D warnings