### PR TITLE
Fix installer metadata fallback and modal layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Fixed
+- **Installer update resolution.** `install.sh` now reads the public
+  `latest.json` metadata before falling back to the GitHub Releases API, so
+  in-app updates keep working when the unauthenticated API returns 403.
+- **Collection Settings and response view layout.** Collection Settings now uses
+  bounded left/right panes so controls cannot collapse into vertical text, and
+  the Response body view switch no longer shows a broken standalone "View"
+  label.
+
 ## [0.27.4] — 2026-06-18
 
 ### Fixed

--- a/install.sh
+++ b/install.sh
@@ -30,8 +30,10 @@
 
 set -euo pipefail
 
-REPO="${RUSTY_REPO:-chud-lori/rusty-requester}"
+DEFAULT_REPO="chud-lori/rusty-requester"
+REPO="${RUSTY_REPO:-$DEFAULT_REPO}"
 TAG="${VERSION:-}"
+STATIC_LATEST_JSON_URL="${RUSTY_LATEST_JSON_URL:-https://chud-lori.github.io/rusty-requester/latest.json}"
 
 red()   { printf "\033[31m%s\033[0m\n" "$*"; }
 green() { printf "\033[32m%s\033[0m\n" "$*"; }
@@ -41,6 +43,18 @@ die()   { red "error: $*"; exit 1; }
 
 require() {
     command -v "$1" >/dev/null 2>&1 || die "'$1' is required but not installed"
+}
+
+parse_latest_tag() {
+    latest_json="$1"
+    tag="$(printf '%s' "$latest_json" | awk -F'"' '/"tag"[[:space:]]*:/ {print $4; exit}')"
+    if [ -z "$tag" ]; then
+        version="$(printf '%s' "$latest_json" | awk -F'"' '/"version"[[:space:]]*:/ {print $4; exit}')"
+        if [ -n "$version" ]; then
+            tag="v${version#v}"
+        fi
+    fi
+    printf '%s' "$tag"
 }
 
 # --- Detect platform -----------------------------------------------------
@@ -114,13 +128,26 @@ fi
 
 # --- Resolve release tag -------------------------------------------------
 if [ -z "${TAG}" ]; then
-    blue "→ Resolving latest release from github.com/${REPO}..."
-    # Capture the full response first — piping curl directly into `awk '... exit}'`
-    # triggers SIGPIPE (curl exit 23 "Failed writing body") under `set -o pipefail`
-    # on Linux, because awk closes the pipe before curl finishes writing.
-    RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest") \
-        || die "couldn't reach GitHub API (rate-limited or offline?)"
-    TAG=$(printf '%s' "$RELEASE_JSON" | awk -F'"' '/"tag_name"/{print $4; exit}')
+    if [ "$REPO" = "$DEFAULT_REPO" ]; then
+        blue "→ Resolving latest release from static metadata..."
+        LATEST_JSON="$(curl -fsSL "$STATIC_LATEST_JSON_URL" 2>/dev/null || true)"
+        TAG="$(parse_latest_tag "$LATEST_JSON")"
+        if [ -n "$TAG" ]; then
+            dim "  metadata: $STATIC_LATEST_JSON_URL"
+        else
+            dim "  static metadata unavailable — falling back to GitHub Releases API"
+        fi
+    fi
+
+    if [ -z "${TAG}" ]; then
+        blue "→ Resolving latest release from github.com/${REPO}..."
+        # Capture the full response first — piping curl directly into `awk '... exit}'`
+        # triggers SIGPIPE (curl exit 23 "Failed writing body") under `set -o pipefail`
+        # on Linux, because awk closes the pipe before curl finishes writing.
+        RELEASE_JSON=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest") \
+            || die "couldn't reach release metadata or GitHub API (rate-limited or offline?)"
+        TAG=$(printf '%s' "$RELEASE_JSON" | awk -F'"' '/"tag_name"/{print $4; exit}')
+    fi
 fi
 if [ -z "${TAG}" ]; then
     die "couldn't resolve a release tag (rate-limited or repo has no releases yet?)"

--- a/src/ui/collection_settings.rs
+++ b/src/ui/collection_settings.rs
@@ -48,10 +48,11 @@ impl ApiClient {
             .title_bar(false)
             .collapsible(false)
             .resizable(true)
-            .default_width(920.0)
-            .default_height(620.0)
-            .min_width(760.0)
-            .min_height(520.0)
+            .default_size(egui::vec2(900.0, 620.0))
+            .min_width(660.0)
+            .min_height(500.0)
+            .max_width(1040.0)
+            .max_height(760.0)
             .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
             .open(&mut open)
             .show(ctx, |ui| {
@@ -71,71 +72,94 @@ impl ApiClient {
                         ui.separator();
                         ui.add_space(12.0);
 
-                        let content_height = (ui.available_height() - 48.0).max(360.0);
-                        ui.horizontal(|ui| {
-                            ui.set_min_height(content_height);
-                            render_section_picker(
-                                ui,
-                                &mut self.collection_settings_section,
-                                git_ready,
-                                is_git_repo,
-                                openapi_ready,
-                            );
+                        let footer_height = 46.0;
+                        let content_height = (ui.available_height() - footer_height).max(320.0);
+                        let content_width = ui.available_width().max(1.0);
+                        let (content_rect, _) = ui.allocate_exact_size(
+                            egui::vec2(content_width, content_height),
+                            egui::Sense::hover(),
+                        );
+                        let nav_width = 210.0_f32.min((content_rect.width() * 0.34).max(180.0));
+                        let gap = 16.0;
+                        let nav_rect = egui::Rect::from_min_max(
+                            content_rect.min,
+                            egui::pos2(content_rect.left() + nav_width, content_rect.bottom()),
+                        );
+                        let detail_rect = egui::Rect::from_min_max(
+                            egui::pos2(content_rect.left() + nav_width + gap, content_rect.top()),
+                            content_rect.max,
+                        );
+                        let divider_x = content_rect.left() + nav_width + gap * 0.5;
+                        ui.painter().line_segment(
+                            [
+                                egui::pos2(divider_x, content_rect.top()),
+                                egui::pos2(divider_x, content_rect.bottom()),
+                            ],
+                            egui::Stroke::new(1.0, border()),
+                        );
 
-                            ui.add_space(10.0);
-                            ui.separator();
-                            ui.add_space(12.0);
+                        let mut nav_ui = ui.new_child(egui::UiBuilder::new().max_rect(nav_rect));
+                        nav_ui.set_clip_rect(nav_rect);
+                        render_section_picker(
+                            &mut nav_ui,
+                            &mut self.collection_settings_section,
+                            git_ready,
+                            is_git_repo,
+                            openapi_ready,
+                        );
 
-                            egui::ScrollArea::vertical()
-                                .id_salt("collection_settings_detail")
-                                .auto_shrink([false, false])
-                                .max_height(content_height)
-                                .show(ui, |ui| {
-                                    ui.set_min_width((ui.available_width() - 8.0).max(520.0));
-                                    match self.collection_settings_section {
-                                        CollectionSettingsSection::Directory => {
-                                            directory_section(
-                                                ui,
-                                                &mut sync.git_workspace_dir,
-                                                git_ready,
-                                                is_git_repo,
-                                                busy,
-                                                &mut changed,
-                                                &mut actions,
-                                            );
-                                        }
-                                        CollectionSettingsSection::Secrets => {
-                                            secrets_section(ui, &mut sync, &mut changed);
-                                        }
-                                        CollectionSettingsSection::Git => {
-                                            git_section(
-                                                ui,
-                                                &mut sync.git_commit_message,
-                                                is_git_repo,
-                                                busy,
-                                                &self.collection_git_status,
-                                                &mut changed,
-                                                &mut actions,
-                                            );
-                                        }
-                                        CollectionSettingsSection::OpenApi => {
-                                            openapi_section(
-                                                ui,
-                                                &mut sync.openapi_spec_path,
-                                                openapi_ready,
-                                                busy,
-                                                &mut changed,
-                                                &mut actions,
-                                            );
-                                        }
+                        let mut detail_ui =
+                            ui.new_child(egui::UiBuilder::new().max_rect(detail_rect));
+                        detail_ui.set_clip_rect(detail_rect);
+                        egui::ScrollArea::vertical()
+                            .id_salt("collection_settings_detail")
+                            .auto_shrink([false, false])
+                            .max_height(content_height)
+                            .show(&mut detail_ui, |ui| {
+                                ui.set_width(ui.available_width().max(360.0));
+                                match self.collection_settings_section {
+                                    CollectionSettingsSection::Directory => {
+                                        directory_section(
+                                            ui,
+                                            &mut sync.git_workspace_dir,
+                                            git_ready,
+                                            is_git_repo,
+                                            busy,
+                                            &mut changed,
+                                            &mut actions,
+                                        );
                                     }
-
-                                    if let Some(sync) = &self.sync_in_flight {
-                                        ui.add_space(12.0);
-                                        sync_status(ui, &sync.label);
+                                    CollectionSettingsSection::Secrets => {
+                                        secrets_section(ui, &mut sync, &mut changed);
                                     }
-                                });
-                        });
+                                    CollectionSettingsSection::Git => {
+                                        git_section(
+                                            ui,
+                                            &mut sync.git_commit_message,
+                                            is_git_repo,
+                                            busy,
+                                            &self.collection_git_status,
+                                            &mut changed,
+                                            &mut actions,
+                                        );
+                                    }
+                                    CollectionSettingsSection::OpenApi => {
+                                        openapi_section(
+                                            ui,
+                                            &mut sync.openapi_spec_path,
+                                            openapi_ready,
+                                            busy,
+                                            &mut changed,
+                                            &mut actions,
+                                        );
+                                    }
+                                }
+
+                                if let Some(sync) = &self.sync_in_flight {
+                                    ui.add_space(12.0);
+                                    sync_status(ui, &sync.label);
+                                }
+                            });
 
                         ui.add_space(10.0);
                         ui.separator();

--- a/src/ui/response.rs
+++ b/src/ui/response.rs
@@ -460,12 +460,7 @@ impl ApiClient {
             );
             let mut view = requested_view;
             ui.horizontal(|ui| {
-                ui.label(
-                    egui::RichText::new("View")
-                        .size(11.0)
-                        .color(muted())
-                        .strong(),
-                );
+                ui.spacing_mut().item_spacing.x = 10.0;
                 render_body_view_selector(
                     ui,
                     &mut view,


### PR DESCRIPTION
## Summary
- resolve install.sh latest release from GitHub Pages latest.json before using the GitHub Releases API
- bound Collection Settings into stable left/right panes so controls cannot collapse into vertical text
- remove the broken standalone Response body View label

## Tests
- bash -n install.sh
- cargo fmt --check
- cargo test -q
- cargo clippy --all-targets -- -D warnings
- git diff --check