### PR TITLE
Fix settings and updater layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Fixed
+- **Collection Settings and updater layout.** Collection Settings no longer
+  lets sidebar selections, note cards, fields, or action buttons overlap, and
+  the in-app updater now shows a bounded sanitized status instead of stretching
+  around raw terminal progress output.
+
 ## [0.27.7] — 2026-06-18
 
 ### Fixed

--- a/src/ui/collection_settings.rs
+++ b/src/ui/collection_settings.rs
@@ -48,7 +48,7 @@ impl ApiClient {
             .title_bar(false)
             .collapsible(false)
             .resizable(false)
-            .fixed_size(egui::vec2(780.0, 520.0))
+            .fixed_size(egui::vec2(820.0, 520.0))
             .anchor(egui::Align2::CENTER_CENTER, egui::vec2(0.0, 0.0))
             .open(&mut open)
             .show(ctx, |ui| {
@@ -68,13 +68,13 @@ impl ApiClient {
                         ui.separator();
                         ui.add_space(12.0);
 
-                        let content_height = (ui.available_height() - 48.0).max(300.0);
+                        let content_height = (ui.available_height() - 44.0).max(320.0);
                         ui.horizontal_top(|ui| {
                             ui.allocate_ui_with_layout(
-                                egui::vec2(176.0, content_height),
+                                egui::vec2(172.0, content_height),
                                 egui::Layout::top_down(egui::Align::Min),
                                 |ui| {
-                                    ui.set_width(176.0);
+                                    ui.set_width(172.0);
                                     ui.set_min_height(content_height);
                                     ui.set_clip_rect(ui.max_rect());
                                     render_section_picker(
@@ -91,7 +91,7 @@ impl ApiClient {
                             ui.separator();
                             ui.add_space(10.0);
 
-                            let detail_width = ui.available_width().clamp(480.0, 540.0);
+                            let detail_width = ui.available_width().min(600.0);
                             ui.allocate_ui_with_layout(
                                 egui::vec2(detail_width, content_height),
                                 egui::Layout::top_down(egui::Align::Min),
@@ -101,9 +101,9 @@ impl ApiClient {
                                     egui::ScrollArea::vertical()
                                         .id_salt("collection_settings_detail")
                                         .auto_shrink([false, false])
-                                        .max_height(content_height)
+                                        .max_height(content_height - 4.0)
                                         .show(ui, |ui| {
-                                            ui.set_width(detail_width - 8.0);
+                                            ui.set_width(detail_width - 14.0);
                                             match self.collection_settings_section {
                                                 CollectionSettingsSection::Directory => {
                                                     directory_section(
@@ -239,7 +239,7 @@ fn render_section_picker(
     openapi_ready: bool,
 ) {
     ui.vertical(|ui| {
-        ui.set_width(176.0);
+        ui.set_width(172.0);
         ui.label(egui::RichText::new("Sections").size(10.5).color(muted()));
         ui.add_space(6.0);
         section_button(
@@ -286,12 +286,6 @@ fn render_section_picker(
             },
             openapi_ready,
         );
-
-        ui.add_space(12.0);
-        info_note(
-            ui,
-            "Private remotes use your local Git credentials. No provider tokens are stored.",
-        );
     });
 }
 
@@ -304,8 +298,9 @@ fn section_button(
     ready: bool,
 ) {
     let active = *selected == section;
-    let desired = egui::vec2(ui.available_width(), 42.0);
-    let (rect, response) = ui.allocate_exact_size(desired, egui::Sense::click());
+    let desired = egui::vec2((ui.available_width() - 6.0).max(120.0), 42.0);
+    let (allocated_rect, response) = ui.allocate_exact_size(desired, egui::Sense::click());
+    let rect = allocated_rect.shrink2(egui::vec2(2.0, 1.0));
     if response.clicked() {
         *selected = section;
     }
@@ -382,23 +377,11 @@ fn directory_section(
         );
     }
     ui.add_space(12.0);
-    ui.horizontal(|ui| {
-        if ui
-            .add_enabled(
-                git_ready && !busy,
-                egui::Button::new("Import from folder").min_size(egui::vec2(132.0, 30.0)),
-            )
-            .clicked()
-        {
+    action_buttons(ui, |ui| {
+        if fixed_button(ui, git_ready && !busy, "Import from folder", 142.0).clicked() {
             actions.import_workspace = true;
         }
-        if ui
-            .add_enabled(
-                git_ready && !busy,
-                egui::Button::new("Export to folder").min_size(egui::vec2(132.0, 30.0)),
-            )
-            .clicked()
-        {
+        if fixed_button(ui, git_ready && !busy, "Export to folder", 132.0).clicked() {
             actions.export_workspace = true;
         }
     });
@@ -459,6 +442,11 @@ fn git_section(
         "Git remote",
         "Pull, review, commit, and push through your existing local Git credentials. Rusty Requester does not store provider tokens.",
     );
+    ui.add_space(8.0);
+    info_note(
+        ui,
+        "Private remotes use your local Git credentials. No provider tokens are stored.",
+    );
     ui.add_space(12.0);
     text_field_group(
         ui,
@@ -468,32 +456,14 @@ fn git_section(
         changed,
     );
     ui.add_space(14.0);
-    ui.horizontal(|ui| {
-        if ui
-            .add_enabled(
-                is_git_repo && !busy,
-                egui::Button::new("Refresh changes").min_size(egui::vec2(130.0, 30.0)),
-            )
-            .clicked()
-        {
+    action_buttons(ui, |ui| {
+        if fixed_button(ui, is_git_repo && !busy, "Refresh changes", 130.0).clicked() {
             actions.refresh_git_status = true;
         }
-        if ui
-            .add_enabled(
-                is_git_repo && !busy,
-                egui::Button::new("Pull from remote").min_size(egui::vec2(130.0, 30.0)),
-            )
-            .clicked()
-        {
+        if fixed_button(ui, is_git_repo && !busy, "Pull from remote", 130.0).clicked() {
             actions.pull_remote = true;
         }
-        if ui
-            .add_enabled(
-                is_git_repo && !busy,
-                egui::Button::new("Commit and push").min_size(egui::vec2(130.0, 30.0)),
-            )
-            .clicked()
-        {
+        if fixed_button(ui, is_git_repo && !busy, "Commit and push", 130.0).clicked() {
             actions.push_remote = true;
         }
     });
@@ -545,21 +515,24 @@ fn openapi_section(
         || actions.choose_openapi_file = true,
     );
     ui.add_space(14.0);
-    if ui
-        .add_enabled(
+    action_buttons(ui, |ui| {
+        if fixed_button(
+            ui,
             openapi_ready && !busy,
-            egui::Button::new("Refresh collection from OpenAPI").min_size(egui::vec2(224.0, 30.0)),
+            "Refresh collection from OpenAPI",
+            230.0,
         )
         .clicked()
-    {
-        actions.refresh_openapi = true;
-    }
+        {
+            actions.refresh_openapi = true;
+        }
+    });
 }
 
 fn section_header(ui: &mut egui::Ui, title: &str, description: &str) {
     ui.label(egui::RichText::new(title).size(15.0).strong().color(text()));
     ui.add_space(4.0);
-    ui.label(egui::RichText::new(description).size(11.0).color(muted()));
+    ui.add(egui::Label::new(egui::RichText::new(description).size(11.0).color(muted())).wrap());
 }
 
 fn path_field_group(
@@ -574,7 +547,7 @@ fn path_field_group(
     ui.add_space(3.0);
     ui.horizontal(|ui| {
         let button_w = 96.0;
-        let input_w = (ui.available_width() - button_w - 8.0).max(300.0);
+        let input_w = (ui.available_width() - button_w - 10.0).max(220.0);
         let response = ui.add_sized(
             [input_w, 30.0],
             egui::TextEdit::singleline(value).hint_text(hint(placeholder)),
@@ -599,10 +572,25 @@ fn text_field_group(
     ui.label(egui::RichText::new(label).size(11.0).color(muted()));
     ui.add_space(3.0);
     let response = ui.add_sized(
-        [ui.available_width().max(360.0), 30.0],
+        [ui.available_width(), 30.0],
         egui::TextEdit::singleline(value).hint_text(hint(placeholder)),
     );
     *changed |= response.changed();
+}
+
+fn action_buttons(ui: &mut egui::Ui, add_contents: impl FnOnce(&mut egui::Ui)) {
+    ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 8.0;
+        ui.set_min_height(32.0);
+        add_contents(ui);
+    });
+}
+
+fn fixed_button(ui: &mut egui::Ui, enabled: bool, label: &str, width: f32) -> egui::Response {
+    ui.add_enabled_ui(enabled, |ui| {
+        ui.add_sized([width, 30.0], egui::Button::new(label))
+    })
+    .inner
 }
 
 fn sync_status(ui: &mut egui::Ui, label: &str) {

--- a/src/ui/modals/update.rs
+++ b/src/ui/modals/update.rs
@@ -339,8 +339,9 @@ impl ApiClient {
             .collapsible(false)
             .resizable(false)
             .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
-            .fixed_size([500.0, 0.0])
+            .fixed_size([500.0, 280.0])
             .show(ctx, |ui| {
+                ui.set_width(464.0);
                 ui.add_space(6.0);
                 render_update_progress_strip(ui, ctx.input(|i| i.time));
                 ui.add_space(14.0);
@@ -369,20 +370,34 @@ impl ApiClient {
                                 .strong(),
                         );
                         ui.add_space(3.0);
-                        ui.label(
-                            egui::RichText::new(
-                                latest_log_line(&tail).unwrap_or("Starting installer..."),
+                        let status = latest_update_status(&tail)
+                            .unwrap_or_else(|| "Starting installer...".to_string());
+                        let status_text = truncate_middle(&status, 92);
+                        let status_rect = ui
+                            .allocate_ui_with_layout(
+                                egui::vec2(ui.available_width(), 18.0),
+                                egui::Layout::left_to_right(egui::Align::Center),
+                                |ui| {
+                                    ui.set_clip_rect(ui.max_rect());
+                                    ui.label(
+                                        egui::RichText::new(status_text)
+                                            .color(muted())
+                                            .font(egui::FontId::monospace(10.5)),
+                                    );
+                                },
                             )
-                            .color(muted())
-                            .font(egui::FontId::monospace(10.5)),
-                        );
+                            .response;
+                        status_rect.on_hover_text(status);
                         ui.add_space(4.0);
+                        let log_label =
+                            truncate_middle(&format!("Log: {}", log_path.display()), 78);
                         ui.label(
-                            egui::RichText::new(format!("Log: {}", log_path.display()))
+                            egui::RichText::new(log_label)
                                 .color(muted())
                                 .size(10.0)
                                 .monospace(),
-                        );
+                        )
+                        .on_hover_text(log_path.display().to_string());
                     });
                 ui.add_space(8.0);
                 ui.horizontal(|ui| {
@@ -614,9 +629,66 @@ fn render_update_progress_strip(ui: &mut egui::Ui, time: f64) {
     );
 }
 
-fn latest_log_line(tail: &str) -> Option<&str> {
-    tail.lines()
+fn latest_update_status(tail: &str) -> Option<String> {
+    tail.split(['\n', '\r'])
         .rev()
-        .map(str::trim)
-        .find(|line| !line.is_empty())
+        .map(strip_terminal_noise)
+        .map(|line| line.trim().to_string())
+        .find(|line| !line.is_empty() && !is_noisy_progress_line(line))
+}
+
+fn strip_terminal_noise(line: &str) -> String {
+    let mut out = String::with_capacity(line.len());
+    let mut chars = line.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            if matches!(chars.peek(), Some('[')) {
+                chars.next();
+                for next in chars.by_ref() {
+                    if next.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+            continue;
+        }
+        if ch.is_control() && ch != '\t' {
+            continue;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn is_noisy_progress_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return true;
+    }
+    if trimmed.starts_with("binary SHA256:") {
+        return true;
+    }
+    let progress_chars = trimmed
+        .chars()
+        .filter(|ch| matches!(ch, '#' | '=' | '-' | 'O' | ' ' | '.' | '%') || ch.is_ascii_digit())
+        .count();
+    progress_chars * 100 / trimmed.chars().count().max(1) > 80
+}
+
+fn truncate_middle(value: &str, max_chars: usize) -> String {
+    let count = value.chars().count();
+    if count <= max_chars {
+        return value.to_string();
+    }
+    let keep_each_side = max_chars.saturating_sub(1) / 2;
+    let start: String = value.chars().take(keep_each_side).collect();
+    let end: String = value
+        .chars()
+        .rev()
+        .take(keep_each_side)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
+    format!("{start}…{end}")
 }


### PR DESCRIPTION
## Summary
- keep Collection Settings controls top-aligned with stable two-pane sizing
- remove overlapping sidebar note/selection fills and move Git credential guidance into the Git section
- bound and sanitize the in-app updater status so raw curl progress cannot stretch the modal

## Tests
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test -q