### PR TITLE
Fix settings field alignment and response search UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Fixed
+- **Settings and response control alignment.** Settings text fields now use
+  consistent framed padding, Response "Sending request" renders as a quiet
+  inline progress state, and the Response body find box no longer squeezes the
+  input when no match count is shown.
+
 ## [0.27.8] — 2026-06-18
 
 ### Fixed

--- a/src/ui/collection_settings.rs
+++ b/src/ui/collection_settings.rs
@@ -544,17 +544,14 @@ fn path_field_group(
     mut choose: impl FnMut(),
 ) {
     ui.label(egui::RichText::new(label).size(11.0).color(muted()));
-    ui.add_space(3.0);
+    ui.add_space(5.0);
     ui.horizontal(|ui| {
         let button_w = 96.0;
         let input_w = (ui.available_width() - button_w - 10.0).max(220.0);
-        let response = ui.add_sized(
-            [input_w, 30.0],
-            egui::TextEdit::singleline(value).hint_text(hint(placeholder)),
-        );
+        let response = framed_text_field(ui, input_w, value, placeholder);
         *changed |= response.changed();
         if ui
-            .add_sized([button_w, 30.0], egui::Button::new("Choose..."))
+            .add_sized([button_w, 34.0], egui::Button::new("Choose..."))
             .clicked()
         {
             choose();
@@ -570,12 +567,34 @@ fn text_field_group(
     changed: &mut bool,
 ) {
     ui.label(egui::RichText::new(label).size(11.0).color(muted()));
-    ui.add_space(3.0);
-    let response = ui.add_sized(
-        [ui.available_width(), 30.0],
-        egui::TextEdit::singleline(value).hint_text(hint(placeholder)),
-    );
+    ui.add_space(5.0);
+    let response = framed_text_field(ui, ui.available_width(), value, placeholder);
     *changed |= response.changed();
+}
+
+fn framed_text_field(
+    ui: &mut egui::Ui,
+    width: f32,
+    value: &mut String,
+    placeholder: &str,
+) -> egui::Response {
+    let frame_width = width.max(120.0);
+    egui::Frame::none()
+        .fill(elevated())
+        .stroke(egui::Stroke::new(1.0, border()))
+        .rounding(egui::Rounding::same(8.0))
+        .inner_margin(egui::Margin::symmetric(10.0, 5.0))
+        .show(ui, |ui| {
+            ui.set_width((frame_width - 20.0).max(80.0));
+            ui.add_sized(
+                [ui.available_width(), 22.0],
+                egui::TextEdit::singleline(value)
+                    .hint_text(hint(placeholder))
+                    .frame(false)
+                    .desired_width(f32::INFINITY),
+            )
+        })
+        .inner
 }
 
 fn action_buttons(ui: &mut egui::Ui, add_contents: impl FnOnce(&mut egui::Ui)) {

--- a/src/ui/response.rs
+++ b/src/ui/response.rs
@@ -35,6 +35,16 @@ impl ApiClient {
                 return;
             }
 
+            if self.is_loading {
+                ui.add(egui::Spinner::new().size(14.0).color(accent()));
+                ui.label(
+                    egui::RichText::new("Sending request...")
+                        .size(12.0)
+                        .color(muted()),
+                );
+                return;
+            }
+
             let sc = status_color(&self.response_status);
             egui::Frame::none()
                 .fill(with_alpha(sc, if is_light() { 22 } else { 34 }))
@@ -501,7 +511,7 @@ impl ApiClient {
                             })
                             .stroke(egui::Stroke::new(1.0, with_alpha(border(), 185)))
                             .rounding(egui::Rounding::same(9.0))
-                            .inner_margin(egui::Margin::symmetric(8.0, 3.0))
+                            .inner_margin(egui::Margin::symmetric(8.0, 4.0))
                             .show(ui, |ui| {
                                 ui.set_width(find_w);
                                 ui.horizontal(|ui| {
@@ -513,13 +523,25 @@ impl ApiClient {
                                         .size(13.0)
                                         .color(muted()),
                                     );
-                                    let count_w = 58.0;
                                     let close_w = 22.0;
-                                    let input_w = (ui.available_width()
-                                        - count_w
-                                        - close_w
-                                        - (ui.spacing().item_spacing.x * 2.0))
-                                        .max(96.0);
+                                    let match_count = count_case_insensitive_matches(
+                                        &self.response_text,
+                                        &self.body_search_query,
+                                    );
+                                    let count_text = if self.body_search_query.is_empty() {
+                                        String::new()
+                                    } else {
+                                        format!("{} hit{}", match_count, plural(match_count))
+                                    };
+                                    let count_w = if count_text.is_empty() { 0.0 } else { 58.0 };
+                                    let gap_w = if count_text.is_empty() {
+                                        ui.spacing().item_spacing.x
+                                    } else {
+                                        ui.spacing().item_spacing.x * 2.0
+                                    };
+                                    let input_w =
+                                        (ui.available_width() - count_w - close_w - gap_w)
+                                            .max(130.0);
                                     let search_resp = ui.add_sized(
                                         [input_w, 22.0],
                                         egui::TextEdit::singleline(&mut self.body_search_query)
@@ -537,23 +559,16 @@ impl ApiClient {
                                         self.body_search_query.clear();
                                     }
 
-                                    let match_count = count_case_insensitive_matches(
-                                        &self.response_text,
-                                        &self.body_search_query,
-                                    );
-                                    let count_text = if self.body_search_query.is_empty() {
-                                        String::new()
-                                    } else {
-                                        format!("{} hit{}", match_count, plural(match_count))
-                                    };
-                                    ui.add_sized(
-                                        [count_w, 20.0],
-                                        egui::Label::new(
-                                            egui::RichText::new(count_text)
-                                                .size(11.0)
-                                                .color(muted()),
-                                        ),
-                                    );
+                                    if !count_text.is_empty() {
+                                        ui.add_sized(
+                                            [count_w, 20.0],
+                                            egui::Label::new(
+                                                egui::RichText::new(count_text)
+                                                    .size(11.0)
+                                                    .color(muted()),
+                                            ),
+                                        );
+                                    }
                                     if close_x_button(ui, "Close search").clicked() {
                                         self.body_search_visible = false;
                                         self.body_search_query.clear();

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -71,10 +71,11 @@ impl ApiClient {
             ui.add_space(10.0);
 
             ui.label(egui::RichText::new("Proxy URL").size(11.5).color(muted()));
-            ui.add(
-                egui::TextEdit::singleline(&mut self.editing_settings.proxy_url)
-                    .hint_text(hint("http://proxy:8080 (leave empty for direct)"))
-                    .desired_width(f32::INFINITY),
+            ui.add_space(5.0);
+            settings_text_field(
+                ui,
+                &mut self.editing_settings.proxy_url,
+                "http://proxy:8080 (leave empty for direct)",
             );
             ui.add_space(10.0);
 
@@ -336,4 +337,23 @@ impl ApiClient {
                 .spawn();
         }
     }
+}
+
+fn settings_text_field(ui: &mut egui::Ui, value: &mut String, placeholder: &str) -> egui::Response {
+    egui::Frame::none()
+        .fill(elevated())
+        .stroke(egui::Stroke::new(1.0, border()))
+        .rounding(egui::Rounding::same(8.0))
+        .inner_margin(egui::Margin::symmetric(10.0, 5.0))
+        .show(ui, |ui| {
+            ui.set_width(ui.available_width().max(240.0));
+            ui.add_sized(
+                [ui.available_width(), 22.0],
+                egui::TextEdit::singleline(value)
+                    .hint_text(hint(placeholder))
+                    .frame(false)
+                    .desired_width(f32::INFINITY),
+            )
+        })
+        .inner
 }


### PR DESCRIPTION
## Summary
- align Collection Settings mask/readable fields with framed padding
- apply the same cleaner input treatment to Settings proxy URL
- render in-flight response state as a quiet spinner/text instead of a status chip
- fix Response body search so the input is not squeezed when match count is empty

## Tests
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test -q