### PR TITLE
Fix response find layout and collection navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Fixed
+- **Request and collection navigation polish.** Response body search no longer
+  overlaps the toolbar edge, newly opened request tabs scroll into view, sidebar
+  request rename fields align with the row, Collection Settings can rename the
+  collection, and collection overview now has a close button plus a cleaner
+  description field.
+
 ## [0.27.9] — 2026-06-19
 
 ### Fixed

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,6 +242,7 @@ struct ApiClient {
     /// into view. Stores `(folder_path, request_id)` of the row to
     /// reveal; cleared by the sidebar once it's done scrolling.
     reveal_in_sidebar_pending: Option<(Vec<String>, String)>,
+    scroll_active_tab_into_view: bool,
 
     /// Pending file-dialog actions — executed at the top of the next
     /// `update()` frame rather than immediately inside the menu closure,
@@ -533,6 +534,7 @@ impl Default for ApiClient {
             request_rename_focus_pending: false,
             last_request_click: None,
             reveal_in_sidebar_pending: None,
+            scroll_active_tab_into_view: false,
             pending_import: false,
             pending_export_json: false,
             pending_export_yaml: false,
@@ -1454,6 +1456,7 @@ impl ApiClient {
             self.selected_request_id = Some(request_id);
         }
         self.state.active_tab_id = self.selected_request_id.clone();
+        self.scroll_active_tab_into_view = true;
 
         // Re-clicking the already-active tab is a no-op — don't wipe
         // the live response by restoring from an empty cache. Only
@@ -1745,6 +1748,7 @@ impl ApiClient {
         });
         self.selected_folder_path = vec![];
         self.selected_request_id = Some(new_id);
+        self.scroll_active_tab_into_view = true;
         self.load_request_for_editing();
         self.save_state();
         self.show_toast("Tab duplicated");

--- a/src/ui/collection_settings.rs
+++ b/src/ui/collection_settings.rs
@@ -41,7 +41,9 @@ impl ApiClient {
 
         let mut open = self.show_collection_settings_modal;
         let mut sync = folder.sync.clone();
+        let mut collection_name = folder.name.clone();
         let mut changed = false;
+        let mut name_changed = false;
         let mut actions = CollectionSettingsActions::default();
 
         egui::Window::new("Collection settings")
@@ -63,7 +65,12 @@ impl ApiClient {
                 egui::Frame::none()
                     .inner_margin(egui::Margin::symmetric(18.0, 14.0))
                     .show(ui, |ui| {
-                        render_header(ui, &folder.name, &mut self.show_collection_settings_modal);
+                        render_header(
+                            ui,
+                            &mut collection_name,
+                            &mut name_changed,
+                            &mut self.show_collection_settings_modal,
+                        );
                         ui.add_space(12.0);
                         ui.separator();
                         ui.add_space(12.0);
@@ -164,9 +171,17 @@ impl ApiClient {
 
         self.show_collection_settings_modal = open && self.show_collection_settings_modal;
 
-        if changed {
+        if changed || name_changed {
             if let Some(folder) = find_folder_by_id_mut(&mut self.state.folders, &folder_id) {
-                folder.sync = sync;
+                if changed {
+                    folder.sync = sync;
+                }
+                if name_changed {
+                    let trimmed = collection_name.trim();
+                    if !trimmed.is_empty() {
+                        folder.name = trimmed.to_string();
+                    }
+                }
                 self.save_state();
             }
         }
@@ -197,7 +212,12 @@ impl ApiClient {
     }
 }
 
-fn render_header(ui: &mut egui::Ui, collection_name: &str, modal_open: &mut bool) {
+fn render_header(
+    ui: &mut egui::Ui,
+    collection_name: &mut String,
+    name_changed: &mut bool,
+    modal_open: &mut bool,
+) {
     ui.horizontal(|ui| {
         ui.vertical(|ui| {
             ui.label(
@@ -206,11 +226,15 @@ fn render_header(ui: &mut egui::Ui, collection_name: &str, modal_open: &mut bool
                     .strong()
                     .color(text()),
             );
-            ui.label(
-                egui::RichText::new(collection_name)
-                    .size(11.0)
-                    .color(muted()),
+            ui.label(egui::RichText::new("Name").size(11.0).color(muted()));
+            ui.add_space(4.0);
+            let response = framed_text_field(
+                ui,
+                ui.available_width().min(420.0),
+                collection_name,
+                "Collection name",
             );
+            *name_changed |= response.changed();
         });
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             if ui
@@ -375,13 +399,20 @@ fn directory_section(
             "Remote pull/push needs the repository root containing .git.",
             C_ORANGE,
         );
+    } else if git_ready {
+        ui.add_space(8.0);
+        status_note(
+            ui,
+            "Directory linked. Click Export now to write reviewable files.",
+            C_GREEN,
+        );
     }
     ui.add_space(12.0);
     action_buttons(ui, |ui| {
         if fixed_button(ui, git_ready && !busy, "Import from folder", 142.0).clicked() {
             actions.import_workspace = true;
         }
-        if fixed_button(ui, git_ready && !busy, "Export to folder", 132.0).clicked() {
+        if fixed_button(ui, git_ready && !busy, "Export now", 112.0).clicked() {
             actions.export_workspace = true;
         }
     });

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -251,6 +251,13 @@ impl ApiClient {
                                                 tab.pinned,
                                                 is_renaming,
                                             );
+                                            if is_active && self.scroll_active_tab_into_view {
+                                                ui.scroll_to_rect(
+                                                    tab_rect,
+                                                    Some(egui::Align::Center),
+                                                );
+                                                self.scroll_active_tab_into_view = false;
+                                            }
 
                                             // Inline rename TextEdit overlay — replaces
                                             // the tab name slot when this tab is the one
@@ -1739,12 +1746,21 @@ impl ApiClient {
                     .auto_shrink([false, false])
                     .show(ui, |ui| {
                         // Title
-                        ui.label(
-                            egui::RichText::new(&folder_snapshot.name)
-                                .size(26.0)
-                                .strong()
-                                .color(text()),
-                        );
+                        ui.horizontal_top(|ui| {
+                            ui.vertical(|ui| {
+                                ui.label(
+                                    egui::RichText::new(&folder_snapshot.name)
+                                        .size(26.0)
+                                        .strong()
+                                        .color(text()),
+                                );
+                            });
+                            ui.with_layout(egui::Layout::right_to_left(egui::Align::Min), |ui| {
+                                if close_x_button(ui, "Close collection overview").clicked() {
+                                    self.viewing_folder_id = None;
+                                }
+                            });
+                        });
                         ui.add_space(6.0);
 
                         // Stats line — "N requests · M subfolders"
@@ -1767,16 +1783,25 @@ impl ApiClient {
                                 .color(muted()),
                         );
                         ui.add_space(4.0);
-                        let desc_resp = ui.add(
-                            egui::TextEdit::multiline(&mut self.editing_folder_desc)
-                                .hint_text(
-                                    "Write a description for this collection. \
-                                     Explain what it's for, any auth quirks, \
-                                     env setup, etc.",
+                        let desc_resp = egui::Frame::none()
+                            .fill(elevated())
+                            .stroke(egui::Stroke::new(1.0, border()))
+                            .rounding(egui::Rounding::same(8.0))
+                            .inner_margin(egui::Margin::symmetric(10.0, 8.0))
+                            .show(ui, |ui| {
+                                ui.set_width(ui.available_width());
+                                ui.add_sized(
+                                    [ui.available_width(), 86.0],
+                                    egui::TextEdit::multiline(&mut self.editing_folder_desc)
+                                        .hint_text(
+                                            "Write a description for this collection. Explain what it's for, auth quirks, env setup, etc.",
+                                        )
+                                        .desired_rows(4)
+                                        .desired_width(f32::INFINITY)
+                                        .frame(false),
                                 )
-                                .desired_rows(4)
-                                .desired_width(f32::INFINITY),
-                        );
+                            })
+                            .inner;
                         if desc_resp.changed() {
                             let new_desc = self.editing_folder_desc.clone();
                             if let Some(folder) =

--- a/src/ui/modals/save_draft.rs
+++ b/src/ui/modals/save_draft.rs
@@ -501,6 +501,7 @@ impl ApiClient {
         });
         self.selected_folder_path = vec![];
         self.selected_request_id = Some(id);
+        self.scroll_active_tab_into_view = true;
         self.load_request_for_editing();
         self.response_text.clear();
         self.response_status.clear();

--- a/src/ui/response.rs
+++ b/src/ui/response.rs
@@ -502,7 +502,8 @@ impl ApiClient {
 
                 if self.body_search_visible {
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                        let find_w = ui.available_width().clamp(230.0, 340.0);
+                        ui.add_space(4.0);
+                        let find_w = response_find_width((ui.available_width() - 4.0).max(0.0));
                         egui::Frame::none()
                             .fill(if is_light() {
                                 egui::Color32::from_rgb(245, 247, 250)
@@ -514,66 +515,73 @@ impl ApiClient {
                             .inner_margin(egui::Margin::symmetric(8.0, 4.0))
                             .show(ui, |ui| {
                                 ui.set_width(find_w);
-                                ui.horizontal(|ui| {
-                                    ui.spacing_mut().item_spacing.x = 6.0;
-                                    ui.label(
-                                        egui::RichText::new(
-                                            egui_phosphor::regular::MAGNIFYING_GLASS,
-                                        )
-                                        .size(13.0)
-                                        .color(muted()),
-                                    );
-                                    let close_w = 22.0;
-                                    let match_count = count_case_insensitive_matches(
-                                        &self.response_text,
-                                        &self.body_search_query,
-                                    );
-                                    let count_text = if self.body_search_query.is_empty() {
-                                        String::new()
-                                    } else {
-                                        format!("{} hit{}", match_count, plural(match_count))
-                                    };
-                                    let count_w = if count_text.is_empty() { 0.0 } else { 58.0 };
-                                    let gap_w = if count_text.is_empty() {
-                                        ui.spacing().item_spacing.x
-                                    } else {
-                                        ui.spacing().item_spacing.x * 2.0
-                                    };
-                                    let input_w =
-                                        (ui.available_width() - count_w - close_w - gap_w)
-                                            .max(130.0);
-                                    let search_resp = ui.add_sized(
-                                        [input_w, 22.0],
-                                        egui::TextEdit::singleline(&mut self.body_search_query)
-                                            .hint_text(hint("Find"))
-                                            .frame(false),
-                                    );
-                                    if self.body_search_focus_pending {
-                                        self.body_search_focus_pending = false;
-                                        search_resp.request_focus();
-                                    }
-                                    if search_resp.has_focus()
-                                        && ui.input(|i| i.key_pressed(egui::Key::Escape))
-                                    {
-                                        self.body_search_visible = false;
-                                        self.body_search_query.clear();
-                                    }
-
-                                    if !count_text.is_empty() {
-                                        ui.add_sized(
-                                            [count_w, 20.0],
-                                            egui::Label::new(
-                                                egui::RichText::new(count_text)
-                                                    .size(11.0)
-                                                    .color(muted()),
-                                            ),
+                                ui.with_layout(
+                                    egui::Layout::left_to_right(egui::Align::Center),
+                                    |ui| {
+                                        ui.spacing_mut().item_spacing.x = 6.0;
+                                        ui.label(
+                                            egui::RichText::new(
+                                                egui_phosphor::regular::MAGNIFYING_GLASS,
+                                            )
+                                            .size(13.0)
+                                            .color(muted()),
                                         );
-                                    }
-                                    if close_x_button(ui, "Close search").clicked() {
-                                        self.body_search_visible = false;
-                                        self.body_search_query.clear();
-                                    }
-                                });
+                                        let close_w = 22.0;
+                                        let match_count = count_case_insensitive_matches(
+                                            &self.response_text,
+                                            &self.body_search_query,
+                                        );
+                                        let count_text = if self.body_search_query.is_empty() {
+                                            String::new()
+                                        } else {
+                                            format!("{} hit{}", match_count, plural(match_count))
+                                        };
+                                        let count_w =
+                                            if count_text.is_empty() { 0.0 } else { 58.0 };
+                                        let gap_w = if count_text.is_empty() {
+                                            ui.spacing().item_spacing.x
+                                        } else {
+                                            ui.spacing().item_spacing.x * 2.0
+                                        };
+                                        let input_w = response_find_input_width(
+                                            ui.available_width(),
+                                            count_w,
+                                            close_w,
+                                            gap_w,
+                                        );
+                                        let search_resp = ui.add_sized(
+                                            [input_w, 22.0],
+                                            egui::TextEdit::singleline(&mut self.body_search_query)
+                                                .hint_text(hint("Find"))
+                                                .frame(false),
+                                        );
+                                        if self.body_search_focus_pending {
+                                            self.body_search_focus_pending = false;
+                                            search_resp.request_focus();
+                                        }
+                                        if search_resp.has_focus()
+                                            && ui.input(|i| i.key_pressed(egui::Key::Escape))
+                                        {
+                                            self.body_search_visible = false;
+                                            self.body_search_query.clear();
+                                        }
+
+                                        if !count_text.is_empty() {
+                                            ui.add_sized(
+                                                [count_w, 20.0],
+                                                egui::Label::new(
+                                                    egui::RichText::new(count_text)
+                                                        .size(11.0)
+                                                        .color(muted()),
+                                                ),
+                                            );
+                                        }
+                                        if close_x_button(ui, "Close search").clicked() {
+                                            self.body_search_visible = false;
+                                            self.body_search_query.clear();
+                                        }
+                                    },
+                                );
                             });
                     });
                 }
@@ -1023,6 +1031,20 @@ fn render_response_metric(ui: &mut egui::Ui, value: &str) -> egui::Response {
         )
         .sense(egui::Sense::hover()),
     )
+}
+
+fn response_find_width(available_width: f32) -> f32 {
+    available_width.clamp(0.0, 340.0)
+}
+
+fn response_find_input_width(
+    available_width: f32,
+    count_width: f32,
+    close_width: f32,
+    gap_width: f32,
+) -> f32 {
+    let max_width = available_width.max(72.0);
+    (available_width - count_width - close_width - gap_width).clamp(72.0, max_width)
 }
 
 fn count_case_insensitive_matches(text: &str, query: &str) -> usize {
@@ -1740,5 +1762,19 @@ mod tests {
         .unwrap();
         assert_eq!(summary.headline, "Non-JSON response");
         assert!(summary.detail.contains("Raw shows the original body"));
+    }
+
+    #[test]
+    fn response_find_width_is_bounded_for_narrow_and_wide_toolbars() {
+        assert_eq!(response_find_width(120.0), 120.0);
+        assert_eq!(response_find_width(240.0), 240.0);
+        assert_eq!(response_find_width(600.0), 340.0);
+    }
+
+    #[test]
+    fn response_find_input_width_reserves_count_and_close_controls() {
+        assert_eq!(response_find_input_width(220.0, 0.0, 22.0, 6.0), 192.0);
+        assert_eq!(response_find_input_width(220.0, 58.0, 22.0, 12.0), 128.0);
+        assert_eq!(response_find_input_width(90.0, 58.0, 22.0, 12.0), 72.0);
     }
 }

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -806,25 +806,25 @@ impl ApiClient {
                     // Same geometry as the name: method_left (10) + method_slot_w (46)
                     let name_start = rect.left() + 10.0 + 46.0;
                     let edit_rect = egui::Rect::from_min_max(
-                        egui::pos2(name_start - 2.0, rect.top() + 3.0),
-                        egui::pos2(rect.right() - 4.0, rect.bottom() - 3.0),
+                        egui::pos2(name_start - 4.0, rect.top() + 2.0),
+                        egui::pos2(rect.right() - 6.0, rect.bottom() - 2.0),
                     );
                     // Visible background + accent border so the input is obvious.
                     ui.painter()
-                        .rect_filled(edit_rect, egui::Rounding::same(4.0), panel_dark());
+                        .rect_filled(edit_rect, egui::Rounding::same(6.0), elevated());
                     ui.painter().rect_stroke(
                         edit_rect,
-                        egui::Rounding::same(4.0),
-                        egui::Stroke::new(1.5, accent()),
+                        egui::Rounding::same(6.0),
+                        egui::Stroke::new(1.0, accent()),
                     );
-                    let inner = edit_rect.shrink2(egui::vec2(6.0, 2.0));
+                    let inner = edit_rect.shrink2(egui::vec2(8.0, 1.0));
                     let edit_resp = ui.put(
                         inner,
                         egui::TextEdit::singleline(&mut self.rename_request_text)
                             .desired_width(inner.width())
                             .frame(false)
                             .text_color(text())
-                            .font(egui::FontId::new(13.0, egui::FontFamily::Proportional)),
+                            .font(egui::FontId::new(12.5, egui::FontFamily::Proportional)),
                     );
                     if self.request_rename_focus_pending {
                         self.request_rename_focus_pending = false;


### PR DESCRIPTION
## Summary
- prevent Response body find from inheriting RTL layout or forcing the toolbar wider than available space
- add regression tests for response find width calculations
- scroll newly opened/created request tabs into view
- align sidebar request rename input with the request row
- add collection rename to Collection Settings and clarify directory link vs export behavior
- add close button and framed description field to collection overview

## Tests
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test -q