### PR TITLE
Fix main window resize and zoom behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Fixed
+- **Window resize and zoom behavior.** The main app window is explicitly
+  resizable, and the macOS custom top chrome now supports window dragging and
+  double-click maximize/restore.
+
 ## [0.27.11] — 2026-06-19
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -418,6 +418,8 @@ struct ApiClient {
     /// default Services/Hide/Quit stub.
     #[cfg(target_os = "macos")]
     macos_menu_installed: bool,
+    #[cfg(target_os = "macos")]
+    main_window_maximized: bool,
 }
 
 impl Default for ApiClient {
@@ -586,6 +588,8 @@ impl Default for ApiClient {
             palette_focus_pending: false,
             #[cfg(target_os = "macos")]
             macos_menu_installed: false,
+            #[cfg(target_os = "macos")]
+            main_window_maximized: false,
         };
         // Attach the startup warning (if any). Consumed by the first
         // `update()` call via `show_toast`.
@@ -3114,6 +3118,7 @@ fn main() -> Result<(), eframe::Error> {
     let mut viewport = egui::ViewportBuilder::default()
         .with_inner_size([1280.0, 820.0])
         .with_min_inner_size([900.0, 600.0])
+        .with_resizable(true)
         .with_title("Rusty Requester")
         // Wayland app_id / X11 WM_CLASS. Must match the `.desktop`
         // file's `StartupWMClass=` so GNOME / KDE can associate the

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -149,20 +149,26 @@ impl ApiClient {
         // chrome. Active tab fill alone signals "selected", no darker
         // horizontal seam between the tab strip and the content below.
         let bar_height = 38.0;
+        #[cfg(target_os = "macos")]
+        let titlebar_drag_height = 28.0;
         egui::Frame::none()
             .fill(crate::theme::bg())
             .inner_margin(egui::Margin {
                 left: 10.0,
                 right: 10.0,
-                // macOS: extra top padding so the tab strip clears the
-                // traffic-light window controls when the title bar is
-                // merged into the chrome.
-                top: if cfg!(target_os = "macos") { 28.0 } else { 4.0 },
+                top: if cfg!(target_os = "macos") { 0.0 } else { 4.0 },
                 bottom: 0.0,
             })
             .show(ui, |ui| {
-                ui.set_min_height(bar_height);
-                ui.set_max_height(bar_height);
+                #[cfg(target_os = "macos")]
+                let total_height = bar_height + titlebar_drag_height;
+                #[cfg(not(target_os = "macos"))]
+                let total_height = bar_height;
+                ui.set_min_height(total_height);
+                ui.set_max_height(total_height);
+
+                #[cfg(target_os = "macos")]
+                self.render_window_drag_strip(ui, titlebar_drag_height);
 
                 let mut activate: Option<usize> = None;
                 let mut close: Option<usize> = None;
@@ -454,6 +460,29 @@ impl ApiClient {
                     }
                 }
             });
+    }
+
+    #[cfg(target_os = "macos")]
+    fn render_window_drag_strip(&mut self, ui: &mut egui::Ui, height: f32) {
+        ui.horizontal(|ui| {
+            // Keep the invisible drag target away from the macOS traffic lights.
+            ui.add_space(74.0);
+            let width = ui.available_width().max(0.0);
+            let (_rect, response) =
+                ui.allocate_exact_size(egui::vec2(width, height), egui::Sense::click_and_drag());
+
+            if response.double_clicked() {
+                let currently_maximized = ui
+                    .ctx()
+                    .input(|i| i.viewport().maximized.unwrap_or(self.main_window_maximized));
+                self.main_window_maximized = !currently_maximized;
+                ui.ctx().send_viewport_cmd(egui::ViewportCommand::Maximized(
+                    self.main_window_maximized,
+                ));
+            } else if response.drag_started() {
+                ui.ctx().send_viewport_cmd(egui::ViewportCommand::StartDrag);
+            }
+        });
     }
 
     /// Open the "Save to folder" modal for the draft at tab index `idx`.


### PR DESCRIPTION
## Summary
- explicitly mark the main viewport as resizable
- add a macOS custom chrome drag strip for moving the window
- support double-click maximize/restore from the custom top chrome

## Test plan
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test