### PR TITLE
Keep focus in response find navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Fixed
+- **Response find focus retention.** Pressing Enter / Shift+Enter in the
+  response find field keeps keyboard focus in the field, so repeated Enter
+  advances through matches without clicking the search box again.
+
 ## [0.27.19] — 2026-06-22
 
 ### Fixed

--- a/src/ui/response.rs
+++ b/src/ui/response.rs
@@ -598,6 +598,7 @@ impl ApiClient {
                                             backward,
                                         );
                                         self.body_search_scroll_pending = true;
+                                        search_resp.request_focus();
                                     }
                                 }
 


### PR DESCRIPTION
## Summary
- keep keyboard focus in the response find field after Enter / Shift+Enter advances a match
- allows repeated Enter presses to step through search results without clicking the field again

## Tests
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test response_find
- cargo test