### PR TITLE
Add HTTP QUERY method support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Added
+- **HTTP QUERY method.** Requests can now use the standardized `QUERY`
+  method for safe, idempotent searches that need a request body. The method is
+  available in the editor, cURL import/export, OpenAPI import, and reviewable
+  `.rr` workspace files.
+
 ## [0.27.21] — 2026-06-22
 
 ### Fixed

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -14,7 +14,7 @@ Full feature catalog for Rusty Requester. For a quick pitch see the
 
 ## Request building
 
-- 🔧 Full HTTP methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, `OPTIONS`
+- 🔧 Full HTTP methods: `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `QUERY`, `HEAD`, `OPTIONS`
 - 📝 Tabbed editor: **Params · Headers · Cookies · Body · Auth · Tests**
 - 🔗 **Bidirectional URL ↔ Params sync** (Postman-style): type `?foo=bar` in the URL bar → params populate the table; edit the table → URL bar rebuilds. Auto-growing "ghost" row.
 - 🍪 Cookies list (merged into a `Cookie` header on send)
@@ -273,6 +273,7 @@ filled pill background — matches Postman's current look):
 - 🟧 **PUT** — deep rust (`#B7410E`)
 - 🔴 **DELETE** — crimson (`#DC2626`)
 - 🟤 **PATCH** — burnt sienna (`#BA7850`)
+- 🟠 **QUERY** — amber gold (`#F59E0B`)
 - ⚪ **HEAD / OPTIONS** — warm muted (`#7E8391`)
 
 The primary UI accent (selected tab, Send button, focus ring) is the brand

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -473,7 +473,7 @@ cargo build --release</code></pre>
         </div>
         <div class="step">
           <h3>Choose method and URL</h3>
-          <p>Pick <strong>GET</strong>, <strong>POST</strong>, <strong>PUT</strong>, <strong>PATCH</strong>, <strong>DELETE</strong>, <strong>HEAD</strong>, or <strong>OPTIONS</strong>. Enter a full URL or one using environment variables like <code>{{base_url}}/users</code>.</p>
+          <p>Pick <strong>GET</strong>, <strong>POST</strong>, <strong>PUT</strong>, <strong>PATCH</strong>, <strong>DELETE</strong>, <strong>QUERY</strong>, <strong>HEAD</strong>, or <strong>OPTIONS</strong>. Enter a full URL or one using environment variables like <code>{{base_url}}/users</code>. Use <strong>QUERY</strong> for safe, idempotent searches that need a request body.</p>
         </div>
         <div class="step">
           <h3>Add request details</h3>

--- a/src/io/curl.rs
+++ b/src/io/curl.rs
@@ -310,6 +310,7 @@ fn parse_method(s: &str) -> HttpMethod {
         "PUT" => HttpMethod::PUT,
         "DELETE" => HttpMethod::DELETE,
         "PATCH" => HttpMethod::PATCH,
+        "QUERY" => HttpMethod::QUERY,
         "HEAD" => HttpMethod::HEAD,
         "OPTIONS" => HttpMethod::OPTIONS,
         _ => HttpMethod::GET,
@@ -580,6 +581,18 @@ mod tests {
         assert_eq!(r.body, "{\"k\":\"v\"}");
         assert!(matches!(r.auth, Auth::Bearer { .. }));
         assert_eq!(r.headers.len(), 1);
+    }
+
+    #[test]
+    fn parse_query_with_body() {
+        let r = parse_curl(
+            "curl -X QUERY 'https://api.example.com/search' \\\n  -H 'Content-Type: application/json' \\\n  --data-raw '{\"filter\":\"active\"}'",
+        )
+        .unwrap();
+
+        assert_eq!(r.method, HttpMethod::QUERY);
+        assert_eq!(r.url, "https://api.example.com/search");
+        assert_eq!(r.body, "{\"filter\":\"active\"}");
     }
 
     #[test]

--- a/src/io/git_workspace.rs
+++ b/src/io/git_workspace.rs
@@ -1111,15 +1111,7 @@ impl BlockRrDocument {
     }
 
     fn take_method_and_url(&mut self) -> Result<(HttpMethod, String), String> {
-        for method in [
-            HttpMethod::GET,
-            HttpMethod::POST,
-            HttpMethod::PUT,
-            HttpMethod::DELETE,
-            HttpMethod::PATCH,
-            HttpMethod::HEAD,
-            HttpMethod::OPTIONS,
-        ] {
+        for method in HttpMethod::ALL {
             let name = method.to_string().to_ascii_lowercase();
             if let Some(dict) = self.take_dict(&name) {
                 let url = take_required_dict_value(&dict, "url")?;
@@ -1728,6 +1720,32 @@ mod tests {
         assert!(exported.contains("params:query {\n  platform: android\n}"));
         assert!(exported.contains("headers {\n  Accept: application/json\n}"));
         assert!(!exported.contains("[query]"));
+        assert_eq!(rr_to_request(&exported).unwrap(), request);
+    }
+
+    #[test]
+    fn native_rr_round_trips_query_method() {
+        let request = Request {
+            id: "request-query".into(),
+            name: "Complex search".into(),
+            description: String::new(),
+            method: HttpMethod::QUERY,
+            url: "https://api.example.com/search".into(),
+            query_params: vec![],
+            path_params: vec![],
+            headers: vec![KvRow::new("Content-Type", "application/json")],
+            cookies: vec![],
+            body: "{\"filter\":\"active\"}".into(),
+            body_ext: None,
+            auth: Auth::None,
+            extractors: vec![],
+            assertions: vec![],
+            source: None,
+        };
+
+        let exported = request_to_rr(&request).unwrap();
+
+        assert!(exported.contains("query {\n  url: https://api.example.com/search\n}"));
         assert_eq!(rr_to_request(&exported).unwrap(), request);
     }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -158,7 +158,9 @@ fn openapi_to_folders(root: &Value) -> Result<Vec<Folder>, String> {
             continue;
         };
 
-        for method_name in ["get", "post", "put", "delete", "patch", "head", "options"] {
+        for method_name in [
+            "get", "post", "put", "delete", "patch", "query", "head", "options",
+        ] {
             let Some(operation) = path_item_obj.get(method_name) else {
                 continue;
             };
@@ -389,6 +391,7 @@ fn openapi_method(method_name: &str) -> Option<HttpMethod> {
         "put" => Some(HttpMethod::PUT),
         "delete" => Some(HttpMethod::DELETE),
         "patch" => Some(HttpMethod::PATCH),
+        "query" => Some(HttpMethod::QUERY),
         "head" => Some(HttpMethod::HEAD),
         "options" => Some(HttpMethod::OPTIONS),
         _ => None,
@@ -997,6 +1000,7 @@ fn parse_method(s: &str) -> HttpMethod {
         "PUT" => HttpMethod::PUT,
         "DELETE" => HttpMethod::DELETE,
         "PATCH" => HttpMethod::PATCH,
+        "QUERY" => HttpMethod::QUERY,
         "HEAD" => HttpMethod::HEAD,
         "OPTIONS" => HttpMethod::OPTIONS,
         _ => HttpMethod::GET,
@@ -1543,6 +1547,38 @@ paths:
         assert_eq!(
             serde_json::from_str::<Value>(&req.body).unwrap(),
             serde_json::json!({"status": "shipped"})
+        );
+    }
+
+    #[test]
+    fn import_openapi_query_operation() {
+        let openapi = r#"
+openapi: 3.1.0
+info:
+  title: Search API
+  version: 1.0.0
+paths:
+  /search:
+    query:
+      summary: Complex search
+      requestBody:
+        content:
+          application/json:
+            example:
+              filter: active
+"#;
+
+        let folders = import_from_str(openapi, "yaml").unwrap();
+        assert_eq!(folders.len(), 1);
+        assert_eq!(folders[0].requests.len(), 1);
+
+        let req = &folders[0].requests[0];
+        assert_eq!(req.name, "Complex search");
+        assert_eq!(req.method, HttpMethod::QUERY);
+        assert_eq!(req.url, "/search");
+        assert_eq!(
+            serde_json::from_str::<Value>(&req.body).unwrap(),
+            serde_json::json!({"filter": "active"})
         );
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -207,8 +207,22 @@ pub enum HttpMethod {
     PUT,
     DELETE,
     PATCH,
+    QUERY,
     HEAD,
     OPTIONS,
+}
+
+impl HttpMethod {
+    pub const ALL: [Self; 8] = [
+        Self::GET,
+        Self::POST,
+        Self::PUT,
+        Self::DELETE,
+        Self::PATCH,
+        Self::QUERY,
+        Self::HEAD,
+        Self::OPTIONS,
+    ];
 }
 
 impl std::fmt::Display for HttpMethod {

--- a/src/net.rs
+++ b/src/net.rs
@@ -184,6 +184,10 @@ pub async fn execute_request_async(
             HttpMethod::PUT => client.put(&final_url),
             HttpMethod::DELETE => client.delete(&final_url),
             HttpMethod::PATCH => client.patch(&final_url),
+            HttpMethod::QUERY => client.request(
+                reqwest::Method::from_bytes(b"QUERY").expect("QUERY is a valid HTTP token"),
+                &final_url,
+            ),
             HttpMethod::HEAD => client.head(&final_url),
             HttpMethod::OPTIONS => client.request(reqwest::Method::OPTIONS, &final_url),
         };

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -122,6 +122,13 @@ pub fn method_color(m: &HttpMethod) -> egui::Color32 {
                 C_PURPLE_LIGHT
             }
         }
+        HttpMethod::QUERY => {
+            if dark_mode {
+                C_ORANGE
+            } else {
+                C_ORANGE_LIGHT
+            }
+        }
         _ => muted(), // theme-aware neutral for HEAD / OPTIONS
     }
 }

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -509,15 +509,7 @@ impl ApiClient {
                         )
                         .width(90.0)
                         .show_ui(ui, |ui| {
-                            for method in [
-                                HttpMethod::GET,
-                                HttpMethod::POST,
-                                HttpMethod::PUT,
-                                HttpMethod::DELETE,
-                                HttpMethod::PATCH,
-                                HttpMethod::HEAD,
-                                HttpMethod::OPTIONS,
-                            ] {
+                            for method in HttpMethod::ALL {
                                 let mc2 = method_color(&method);
                                 if ui
                                     .selectable_value(


### PR DESCRIPTION
## Summary
- Add first-class HTTP QUERY method support in the model, editor dropdown, method colors, and request execution path
- Support QUERY in cURL import/export, OpenAPI import, and reviewable .rr workspace files
- Document QUERY in the feature catalog and docs usage page

## Tests
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test