### PR TITLE
Fix cURL auth and cookie import UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Fixed
+- **cURL auth and cookie import.** Pasted cURL commands now detect Bearer
+  tokens from tighter `Authorization:Bearer ...` header formatting and
+  `--oauth2-bearer`, parse `Cookie:` headers into the Cookies tab, and render
+  Bearer / Basic auth inputs as compact key/value rows with an explicit
+  show/hide token control.
+
 ## [0.28.0] — 2026-06-24
 
 ### Added

--- a/src/io/curl.rs
+++ b/src/io/curl.rs
@@ -11,6 +11,34 @@ pub fn to_curl_redacted(req: &Request) -> String {
     to_curl_inner(req, true)
 }
 
+pub fn bearer_token_from_authorization_header(value: &str) -> Option<String> {
+    let mut parts = value.trim().splitn(2, char::is_whitespace);
+    let scheme = parts.next()?.trim();
+    if !scheme.eq_ignore_ascii_case("bearer") {
+        return None;
+    }
+    let token = parts.next()?.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_string())
+    }
+}
+
+fn parse_cookie_header(value: &str) -> Vec<KvRow> {
+    value
+        .split(';')
+        .filter_map(|part| {
+            let part = part.trim();
+            if part.is_empty() {
+                return None;
+            }
+            let (key, value) = part.split_once('=')?;
+            Some(KvRow::new(key.trim(), value.trim()))
+        })
+        .collect()
+}
+
 fn to_curl_inner(req: &Request, redact: bool) -> String {
     let mut parts: Vec<String> = Vec::new();
     parts.push("curl".to_string());
@@ -198,6 +226,14 @@ pub fn parse_curl(input: &str) -> Result<Request, String> {
                     };
                 }
             }
+            "--oauth2-bearer" => {
+                i += 1;
+                if i < tokens.len() && matches!(auth, Auth::None) {
+                    auth = Auth::Bearer {
+                        token: tokens[i].trim().to_string(),
+                    };
+                }
+            }
             "--url" => {
                 i += 1;
                 if i < tokens.len() {
@@ -213,15 +249,7 @@ pub fn parse_curl(input: &str) -> Result<Request, String> {
             "-b" | "--cookie" => {
                 i += 1;
                 if i < tokens.len() {
-                    for part in tokens[i].split(';') {
-                        let part = part.trim();
-                        if part.is_empty() {
-                            continue;
-                        }
-                        if let Some((k, v)) = part.split_once('=') {
-                            cookies.push(KvRow::new(k.trim(), v.trim()));
-                        }
-                    }
+                    cookies.extend(parse_cookie_header(&tokens[i]));
                 }
             }
             "-e" | "--referer" => {
@@ -268,17 +296,18 @@ pub fn parse_curl(input: &str) -> Result<Request, String> {
     let mut filtered_headers: Vec<KvRow> = Vec::new();
     for h in headers {
         if h.key.eq_ignore_ascii_case("Authorization") {
-            let trimmed = h.value.trim();
-            if let Some(rest) = trimmed
-                .strip_prefix("Bearer ")
-                .or_else(|| trimmed.strip_prefix("bearer "))
-            {
+            if let Some(token) = bearer_token_from_authorization_header(&h.value) {
                 if matches!(auth, Auth::None) {
-                    auth = Auth::Bearer {
-                        token: rest.to_string(),
-                    };
+                    auth = Auth::Bearer { token };
                     continue;
                 }
+            }
+        }
+        if h.key.eq_ignore_ascii_case("Cookie") {
+            let parsed = parse_cookie_header(&h.value);
+            if !parsed.is_empty() {
+                cookies.extend(parsed);
+                continue;
             }
         }
         filtered_headers.push(h);
@@ -579,8 +608,38 @@ mod tests {
         .unwrap();
         assert_eq!(r.method, HttpMethod::POST);
         assert_eq!(r.body, "{\"k\":\"v\"}");
-        assert!(matches!(r.auth, Auth::Bearer { .. }));
+        assert!(matches!(r.auth, Auth::Bearer { token } if token == "abc123"));
         assert_eq!(r.headers.len(), 1);
+    }
+
+    #[test]
+    fn parse_bearer_header_without_space_after_colon() {
+        let r =
+            parse_curl("curl https://api.example.com -H 'Authorization:Bearer abc123'").unwrap();
+
+        assert!(matches!(r.auth, Auth::Bearer { token } if token == "abc123"));
+        assert!(r.headers.is_empty());
+    }
+
+    #[test]
+    fn parse_oauth2_bearer_flag() {
+        let r = parse_curl("curl https://api.example.com --oauth2-bearer abc123").unwrap();
+
+        assert!(matches!(r.auth, Auth::Bearer { token } if token == "abc123"));
+        assert!(r.headers.is_empty());
+    }
+
+    #[test]
+    fn parse_cookie_header_into_cookies_tab() {
+        let r =
+            parse_curl("curl https://api.example.com -H 'Cookie: sid=abc; theme=dark'").unwrap();
+
+        assert!(r.headers.is_empty());
+        assert_eq!(r.cookies.len(), 2);
+        assert_eq!(r.cookies[0].key, "sid");
+        assert_eq!(r.cookies[0].value, "abc");
+        assert_eq!(r.cookies[1].key, "theme");
+        assert_eq!(r.cookies[1].value, "dark");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,6 +148,7 @@ struct ApiClient {
     editing_cookies: Vec<KvRow>,
     editing_body_ext: Option<BodyExt>,
     editing_auth: Auth,
+    show_bearer_token: bool,
     editing_extractors: Vec<ResponseExtractor>,
     editing_assertions: Vec<ResponseAssertion>,
     /// Transient per-send outcomes — populated by
@@ -493,6 +494,7 @@ impl Default for ApiClient {
             editing_cookies: vec![],
             editing_body_ext: None,
             editing_auth: Auth::None,
+            show_bearer_token: false,
             editing_extractors: vec![],
             editing_assertions: vec![],
             assertion_results: vec![],

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -10,6 +10,85 @@ use crate::widgets::*;
 use crate::ApiClient;
 use eframe::egui;
 
+fn auth_header(ui: &mut egui::Ui) {
+    let label_w = 112.0;
+    let gap = 12.0;
+    ui.horizontal(|ui| {
+        ui.add_sized(
+            [label_w, 16.0],
+            egui::Label::new(egui::RichText::new("KEY").size(10.0).color(muted())),
+        );
+        ui.add_space(gap);
+        ui.add_sized(
+            [ui.available_width(), 16.0],
+            egui::Label::new(egui::RichText::new("VALUE").size(10.0).color(muted())),
+        );
+    });
+    ui.add_space(2.0);
+    ui.painter().line_segment(
+        [
+            egui::pos2(ui.cursor().left(), ui.cursor().top()),
+            egui::pos2(ui.cursor().left() + ui.available_width(), ui.cursor().top()),
+        ],
+        egui::Stroke::new(
+            1.0,
+            with_alpha(border(), if is_light() { 160 } else { 110 }),
+        ),
+    );
+    ui.add_space(4.0);
+}
+
+fn auth_field_row(
+    ui: &mut egui::Ui,
+    id: impl std::hash::Hash,
+    label: &str,
+    value: &mut String,
+    placeholder: &str,
+    password: bool,
+    reserve_right: f32,
+) -> bool {
+    let label_w = 112.0;
+    let row_h = 30.0;
+    let gap = 12.0;
+    let mut changed = false;
+
+    let bg = if is_light() {
+        with_alpha(border(), 46)
+    } else {
+        with_alpha(elevated(), 54)
+    };
+    egui::Frame::none()
+        .fill(bg)
+        .rounding(egui::Rounding::same(7.0))
+        .inner_margin(egui::Margin::symmetric(8.0, 4.0))
+        .show(ui, |ui| {
+            ui.horizontal(|ui| {
+                ui.add_sized(
+                    [label_w, row_h],
+                    egui::Label::new(egui::RichText::new(label).color(muted()).size(12.0)),
+                );
+                ui.add_space(gap);
+                let width = (ui.available_width() - reserve_right).max(140.0);
+                if ui
+                    .add_sized(
+                        [width, row_h],
+                        egui::TextEdit::singleline(value)
+                            .id(ui.make_persistent_id(id))
+                            .hint_text(hint(placeholder))
+                            .password(password)
+                            .text_color(text())
+                            .frame(false),
+                    )
+                    .changed()
+                {
+                    changed = true;
+                }
+            });
+        });
+
+    changed
+}
+
 impl ApiClient {
     pub(crate) fn render_central(&mut self, ctx: &egui::Context) {
         let theme_bg = crate::theme::palette_for(self.effective_theme()).bg;
@@ -1065,7 +1144,12 @@ impl ApiClient {
                 AuthKind::Bearer => Auth::Bearer {
                     token: match &self.editing_auth {
                         Auth::Bearer { token } => token.clone(),
-                        _ => String::new(),
+                        _ => self
+                            .editing_headers
+                            .iter()
+                            .find(|h| h.key.eq_ignore_ascii_case("Authorization"))
+                            .and_then(|h| curl::bearer_token_from_authorization_header(&h.value))
+                            .unwrap_or_default(),
                     },
                 },
                 AuthKind::Basic => match &self.editing_auth {
@@ -1098,18 +1182,26 @@ impl ApiClient {
                 );
             }
             Auth::Bearer { token } => {
-                ui.label(egui::RichText::new("Token").color(accent()));
-                if ui
-                    .add(
-                        egui::TextEdit::singleline(token)
-                            .desired_width(ui.available_width())
-                            .password(false)
-                            .hint_text(hint("eyJhbGciOi...")),
-                    )
-                    .changed()
-                {
-                    changed = true;
-                }
+                auth_header(ui);
+                ui.horizontal(|ui| {
+                    changed |= auth_field_row(
+                        ui,
+                        "auth_bearer_token",
+                        "Token",
+                        token,
+                        "Bearer token",
+                        !self.show_bearer_token,
+                        38.0,
+                    );
+                    let (icon, label) = if self.show_bearer_token {
+                        (egui_phosphor::regular::EYE_SLASH, "Hide token")
+                    } else {
+                        (egui_phosphor::regular::EYE, "Show token")
+                    };
+                    if icon_btn(ui, icon, label).clicked() {
+                        self.show_bearer_token = !self.show_bearer_token;
+                    }
+                });
                 // JWT decoder — if the token looks like `header.payload.sig`
                 // with 2 dots and each part is base64url-ish, render the
                 // decoded header + payload below.
@@ -1160,31 +1252,26 @@ impl ApiClient {
                 }
             }
             Auth::Basic { username, password } => {
-                ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new("Username").color(accent()));
-                    if ui
-                        .add(
-                            egui::TextEdit::singleline(username)
-                                .desired_width(ui.available_width() - 100.0),
-                        )
-                        .changed()
-                    {
-                        changed = true;
-                    }
-                });
-                ui.horizontal(|ui| {
-                    ui.label(egui::RichText::new("Password").color(accent()));
-                    if ui
-                        .add(
-                            egui::TextEdit::singleline(password)
-                                .desired_width(ui.available_width() - 100.0)
-                                .password(true),
-                        )
-                        .changed()
-                    {
-                        changed = true;
-                    }
-                });
+                auth_header(ui);
+                changed |= auth_field_row(
+                    ui,
+                    "auth_basic_username",
+                    "Username",
+                    username,
+                    "username",
+                    false,
+                    0.0,
+                );
+                ui.add_space(4.0);
+                changed |= auth_field_row(
+                    ui,
+                    "auth_basic_password",
+                    "Password",
+                    password,
+                    "password",
+                    true,
+                    0.0,
+                );
             }
             Auth::OAuth2(s) => {
                 // Config form — six fields. Stored persistently on


### PR DESCRIPTION
## Summary
- Detect Bearer tokens from compact Authorization headers and --oauth2-bearer during cURL import
- Parse Cookie headers into the Cookies tab instead of leaving them as raw headers
- Restyle Bearer and Basic auth fields as compact key/value rows and add a Bearer show/hide toggle

## Tests
- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test