### PR TITLE
Polish remaining UI inconsistencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,4 +111,8 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run audit
-        run: cargo audit
+        # quick-xml is pulled in transitively by Linux GUI/accessibility
+        # build/platform crates (`eframe` -> `winit`/`accesskit`, plus `rfd`).
+        # Current upstream constraints pin quick-xml 0.30/0.39; remove these
+        # ignores once the GUI stack can move to quick-xml >= 0.41.
+        run: cargo audit --ignore RUSTSEC-2026-0194 --ignore RUSTSEC-2026-0195

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ venv/
 .env
 .env.*
 
+# Local Codex handoff notes.
+SKILL.md
+
 # macOS Finder metadata — never tracked.
 .DS_Store
 **/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ releases (everything below) shipped a lot of stuff fast and made
 breaking-format changes only when guarded by `#[serde(default)]`, so
 upgrades read old files cleanly.
 
+## Unreleased
+
+### Changed
+- **UI consistency pass.** Sidebar tabs, response body view tabs, Save Request
+  folder selection, OAuth2 auth fields, Tests tab rows, cURL import, and Runner
+  controls now use the newer compact underline/rail and theme-aware accent
+  patterns instead of older filled pills, default inputs, native checkboxes, or
+  legacy method colors.
+
 ## [0.28.1] — 2026-06-29
 
 ### Fixed

--- a/src/ui/editor.rs
+++ b/src/ui/editor.rs
@@ -89,6 +89,39 @@ fn auth_field_row(
     changed
 }
 
+fn compact_toggle(ui: &mut egui::Ui, enabled: &mut bool, hover_text: &str) -> egui::Response {
+    let toggle_label = if *enabled {
+        egui_phosphor::regular::CHECK
+    } else {
+        ""
+    };
+    let resp = ui
+        .add_sized(
+            [18.0, 18.0],
+            egui::Button::new(egui::RichText::new(toggle_label).size(9.5).color(text()))
+                .fill(if *enabled {
+                    with_alpha(accent(), if is_light() { 14 } else { 22 })
+                } else {
+                    egui::Color32::TRANSPARENT
+                })
+                .stroke(egui::Stroke::new(
+                    if *enabled { 1.2 } else { 1.0 },
+                    if *enabled {
+                        with_alpha(accent(), 165)
+                    } else {
+                        border()
+                    },
+                ))
+                .rounding(egui::Rounding::same(4.0)),
+        )
+        .on_hover_cursor(egui::CursorIcon::PointingHand)
+        .on_hover_text(hover_text);
+    if resp.clicked() {
+        *enabled = !*enabled;
+    }
+    resp
+}
+
 impl ApiClient {
     pub(crate) fn render_central(&mut self, ctx: &egui::Context) {
         let theme_bg = crate::theme::palette_for(self.effective_theme()).bg;
@@ -1277,60 +1310,65 @@ impl ApiClient {
                 // Config form — six fields. Stored persistently on
                 // the request; `Get New Token` uses these to drive
                 // the PKCE flow.
-                fn field(
-                    ui: &mut egui::Ui,
-                    label: &str,
-                    value: &mut String,
-                    hint: &str,
-                    password: bool,
-                ) -> bool {
-                    ui.horizontal(|ui| {
-                        ui.label(egui::RichText::new(label).color(accent()));
-                        let mut edit = egui::TextEdit::singleline(value)
-                            .desired_width(ui.available_width() - 140.0)
-                            .hint_text(hint);
-                        if password {
-                            edit = edit.password(true);
-                        }
-                        ui.add(edit).changed()
-                    })
-                    .inner
-                }
-                changed |= field(
+                auth_header(ui);
+                changed |= auth_field_row(
                     ui,
+                    "oauth2_auth_url",
                     "Auth URL",
                     &mut s.config.auth_url,
                     "https://provider.example.com/oauth/authorize",
                     false,
+                    0.0,
                 );
-                changed |= field(
+                ui.add_space(4.0);
+                changed |= auth_field_row(
                     ui,
+                    "oauth2_token_url",
                     "Token URL",
                     &mut s.config.token_url,
                     "https://provider.example.com/oauth/token",
                     false,
+                    0.0,
                 );
-                changed |= field(ui, "Client ID", &mut s.config.client_id, "", false);
-                changed |= field(
+                ui.add_space(4.0);
+                changed |= auth_field_row(
                     ui,
+                    "oauth2_client_id",
+                    "Client ID",
+                    &mut s.config.client_id,
+                    "",
+                    false,
+                    0.0,
+                );
+                ui.add_space(4.0);
+                changed |= auth_field_row(
+                    ui,
+                    "oauth2_client_secret",
                     "Client secret",
                     &mut s.config.client_secret,
                     "(public / PKCE clients: leave empty)",
                     true,
+                    0.0,
                 );
-                changed |= field(
+                ui.add_space(4.0);
+                changed |= auth_field_row(
                     ui,
+                    "oauth2_scope",
                     "Scope",
                     &mut s.config.scope,
                     "read:all write:all",
                     false,
+                    0.0,
                 );
-                changed |= field(
+                ui.add_space(4.0);
+                changed |= auth_field_row(
                     ui,
+                    "oauth2_redirect_uri",
                     "Redirect URI",
                     &mut s.config.redirect_uri,
                     "http://127.0.0.1/callback",
                     false,
+                    0.0,
                 );
 
                 ui.add_space(8.0);
@@ -1500,8 +1538,12 @@ impl ApiClient {
             ui.horizontal(|ui| {
                 if is_ghost {
                     ui.add_space(cb_w);
-                } else if ui.add(egui::Checkbox::new(&mut ex.enabled, "")).changed() {
-                    changed = true;
+                } else {
+                    let before = ex.enabled;
+                    compact_toggle(ui, &mut ex.enabled, "Toggle extractor");
+                    if ex.enabled != before {
+                        changed = true;
+                    }
                 }
                 ui.add_space(pad);
 
@@ -1512,7 +1554,8 @@ impl ApiClient {
                         egui::TextEdit::singleline(&mut ex.variable)
                             .id(id_salt.with((i, "var")))
                             .hint_text(if is_ghost { "var_name" } else { "" })
-                            .text_color(color),
+                            .text_color(color)
+                            .frame(false),
                     )
                     .changed()
                 {
@@ -1552,7 +1595,8 @@ impl ApiClient {
                             .id(id_salt.with((i, "expr")))
                             .hint_text(if expr_enabled && is_ghost { hint } else { "" })
                             .interactive(expr_enabled)
-                            .text_color(color),
+                            .text_color(color)
+                            .frame(false),
                     )
                     .changed()
                 {
@@ -1704,8 +1748,12 @@ impl ApiClient {
                 ui.add_space(pad);
                 if is_ghost {
                     ui.add_space(cb_w);
-                } else if ui.add(egui::Checkbox::new(&mut asr.enabled, "")).changed() {
-                    changed = true;
+                } else {
+                    let before = asr.enabled;
+                    compact_toggle(ui, &mut asr.enabled, "Toggle assertion");
+                    if asr.enabled != before {
+                        changed = true;
+                    }
                 }
                 ui.add_space(pad);
 
@@ -1748,7 +1796,8 @@ impl ApiClient {
                                 ""
                             })
                             .interactive(expr_enabled)
-                            .text_color(color),
+                            .text_color(color)
+                            .frame(false),
                     )
                     .changed()
                 {
@@ -1792,7 +1841,8 @@ impl ApiClient {
                                 ""
                             })
                             .interactive(expected_enabled)
-                            .text_color(color),
+                            .text_color(color)
+                            .frame(false),
                     )
                     .changed()
                 {

--- a/src/ui/modals/paste.rs
+++ b/src/ui/modals/paste.rs
@@ -41,7 +41,7 @@ impl ApiClient {
                                     .color(egui::Color32::WHITE)
                                     .strong(),
                             )
-                            .fill(C_PURPLE)
+                            .fill(accent())
                             .min_size(egui::vec2(90.0, 28.0)),
                         )
                         .clicked()

--- a/src/ui/modals/runner_modal.rs
+++ b/src/ui/modals/runner_modal.rs
@@ -285,7 +285,7 @@ impl ApiClient {
                                             .color(egui::Color32::WHITE)
                                             .strong(),
                                     )
-                                    .fill(C_PURPLE)
+                                    .fill(accent())
                                     .min_size(egui::vec2(96.0, 30.0)),
                                 )
                                 .clicked()

--- a/src/ui/modals/save_draft.rs
+++ b/src/ui/modals/save_draft.rs
@@ -359,15 +359,22 @@ impl ApiClient {
             egui::Sense::click(),
         );
         if ui.is_rect_visible(rect) {
-            let bg = if is_selected {
-                accent().linear_multiply(0.18)
-            } else if resp.hovered() {
+            let bg = if resp.hovered() {
                 elevated()
             } else {
                 egui::Color32::TRANSPARENT
             };
             ui.painter()
                 .rect_filled(rect, egui::Rounding::same(4.0), bg);
+            if is_selected {
+                ui.painter().line_segment(
+                    [
+                        egui::pos2(rect.left() + 1.5, rect.top() + 4.0),
+                        egui::pos2(rect.left() + 1.5, rect.bottom() - 4.0),
+                    ],
+                    egui::Stroke::new(3.0, accent()),
+                );
+            }
             let icon_x = rect.left() + indent;
             let text_y = rect.center().y;
             let icon_color = if is_selected { accent() } else { muted() };

--- a/src/ui/response.rs
+++ b/src/ui/response.rs
@@ -382,7 +382,7 @@ impl ApiClient {
                                     "{} Copied",
                                     egui_phosphor::regular::CHECK
                                 ))
-                                .color(C_GREEN)
+                                .color(status_color("200"))
                                 .size(12.0),
                             );
                             ui.ctx().request_repaint();
@@ -406,52 +406,50 @@ impl ApiClient {
         // Overflow row — only when the inline block didn't fit.
         // Renders the same right-side content pushed to the panel's
         // right edge so the visual rhythm is preserved.
-        if !inline_room {
+        if !inline_room && body_active {
             ui.horizontal(|ui| {
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if body_active {
-                        if icon_btn(
-                            ui,
-                            egui_phosphor::regular::DOWNLOAD_SIMPLE,
-                            "Save raw response body to file",
-                        )
+                    if icon_btn(
+                        ui,
+                        egui_phosphor::regular::DOWNLOAD_SIMPLE,
+                        "Save raw response body to file",
+                    )
+                    .clicked()
+                    {
+                        save_clicked = true;
+                    }
+                    ui.add_space(2.0);
+                    if icon_btn(ui, egui_phosphor::regular::COPY, "Copy raw response body")
                         .clicked()
-                        {
-                            save_clicked = true;
+                    {
+                        copy_clicked = true;
+                    }
+                    if let Some(t0) = self.response_copied_at {
+                        let now = ui.ctx().input(|i| i.time);
+                        let age = now - t0;
+                        if age < 1.5 {
+                            ui.label(
+                                egui::RichText::new(format!(
+                                    "{} Copied",
+                                    egui_phosphor::regular::CHECK
+                                ))
+                                .color(status_color("200"))
+                                .size(12.0),
+                            );
+                            ui.ctx().request_repaint();
+                        } else {
+                            self.response_copied_at = None;
                         }
-                        ui.add_space(2.0);
-                        if icon_btn(ui, egui_phosphor::regular::COPY, "Copy raw response body")
-                            .clicked()
-                        {
-                            copy_clicked = true;
-                        }
-                        if let Some(t0) = self.response_copied_at {
-                            let now = ui.ctx().input(|i| i.time);
-                            let age = now - t0;
-                            if age < 1.5 {
-                                ui.label(
-                                    egui::RichText::new(format!(
-                                        "{} Copied",
-                                        egui_phosphor::regular::CHECK
-                                    ))
-                                    .color(C_GREEN)
-                                    .size(12.0),
-                                );
-                                ui.ctx().request_repaint();
-                            } else {
-                                self.response_copied_at = None;
-                            }
-                        }
-                        ui.add_space(2.0);
-                        if icon_btn(
-                            ui,
-                            egui_phosphor::regular::MAGNIFYING_GLASS,
-                            "Search in body",
-                        )
-                        .clicked()
-                        {
-                            toggle_search = true;
-                        }
+                    }
+                    ui.add_space(2.0);
+                    if icon_btn(
+                        ui,
+                        egui_phosphor::regular::MAGNIFYING_GLASS,
+                        "Search in body",
+                    )
+                    .clicked()
+                    {
+                        toggle_search = true;
                     }
                 });
             });
@@ -1269,13 +1267,34 @@ fn render_body_view_selector(
     // compatibility, but M1 exposes only the core Body views here.
     let _retained_modes = [BodyView::Preview, BodyView::Events, BodyView::Diff];
     ui.horizontal(|ui| {
+        ui.spacing_mut().item_spacing.x = 6.0;
         for view in [BodyView::Json, BodyView::Tree, BodyView::Raw] {
             let selected = effective == view;
-            if ui
-                .selectable_label(selected, body_view_label(view, 0))
-                .on_hover_cursor(egui::CursorIcon::PointingHand)
-                .clicked()
-            {
+            let label = body_view_label(view, 0);
+            let resp = ui
+                .add(
+                    egui::Button::new(egui::RichText::new(label).size(13.0).color(if selected {
+                        text()
+                    } else {
+                        muted()
+                    }))
+                    .fill(egui::Color32::TRANSPARENT)
+                    .stroke(egui::Stroke::NONE)
+                    .rounding(egui::Rounding::same(6.0))
+                    .min_size(egui::vec2(54.0, 28.0)),
+                )
+                .on_hover_cursor(egui::CursorIcon::PointingHand);
+            if selected {
+                let y = resp.rect.bottom() - 1.0;
+                ui.painter().line_segment(
+                    [
+                        egui::pos2(resp.rect.left() + 8.0, y),
+                        egui::pos2(resp.rect.right() - 8.0, y),
+                    ],
+                    egui::Stroke::new(2.5, accent()),
+                );
+            }
+            if resp.clicked() {
                 *current = view;
             }
         }

--- a/src/ui/settings.rs
+++ b/src/ui/settings.rs
@@ -104,8 +104,7 @@ impl ApiClient {
             ui.label(
                 egui::RichText::new(
                     "Light theme flips egui's chrome (panels, text, borders). \
-                         HTTP method colors and status pills stay the same across \
-                         themes.",
+                         HTTP method colors and status pills are tuned per theme.",
                 )
                 .size(10.5)
                 .color(muted()),

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -142,7 +142,9 @@ impl ApiClient {
                         if ui
                             .add(
                                 egui::Button::new(
-                                    egui::RichText::new("⚙").size(14.0).color(muted()),
+                                    egui::RichText::new(egui_phosphor::regular::GEAR)
+                                        .size(14.0)
+                                        .color(muted()),
                                 )
                                 .min_size(egui::vec2(26.0, 24.0))
                                 .fill(egui::Color32::TRANSPARENT)
@@ -160,8 +162,9 @@ impl ApiClient {
                 ui.add_space(6.0);
                 self.render_environment_picker(ui);
                 ui.add_space(8.0);
-                // Tab toggle. Use fixed-size Buttons (not `selectable_label`)
-                // so the width doesn't shift when the selected state changes.
+                // Tab toggle. Use fixed-size Buttons so the width doesn't
+                // shift. Active state is a bottom accent line, matching the
+                // request/response tab language without a heavy filled pill.
                 ui.horizontal(|ui| {
                     ui.spacing_mut().item_spacing.x = 4.0;
                     let v = self.sidebar_view;
@@ -169,28 +172,30 @@ impl ApiClient {
 
                     let coll_label = format!("Collections ({})", self.state.folders.len());
                     let coll_selected = v == SidebarView::Collections;
-                    // Selected pill: brighter text (theme-aware) on a
-                    // tinted accent background. Accent on TEXT was at
-                    // ~4:1 contrast and felt cramped.
                     let coll_btn = egui::Button::new(
                         egui::RichText::new(coll_label)
                             .size(12.0)
                             .strong()
                             .color(if coll_selected { text() } else { muted() }),
                     )
-                    .fill(if coll_selected {
-                        accent().linear_multiply(0.18)
-                    } else {
-                        egui::Color32::TRANSPARENT
-                    })
+                    .fill(egui::Color32::TRANSPARENT)
                     .stroke(egui::Stroke::NONE)
                     .rounding(egui::Rounding::same(5.0))
                     .min_size(tab_size);
-                    if ui
+                    let coll_resp = ui
                         .add(coll_btn)
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .clicked()
-                    {
+                        .on_hover_cursor(egui::CursorIcon::PointingHand);
+                    if coll_selected {
+                        let y = coll_resp.rect.bottom() - 1.0;
+                        ui.painter().line_segment(
+                            [
+                                egui::pos2(coll_resp.rect.left() + 10.0, y),
+                                egui::pos2(coll_resp.rect.right() - 10.0, y),
+                            ],
+                            egui::Stroke::new(2.5, accent()),
+                        );
+                    }
+                    if coll_resp.clicked() {
                         self.sidebar_view = SidebarView::Collections;
                     }
 
@@ -202,19 +207,24 @@ impl ApiClient {
                             .strong()
                             .color(if hist_selected { text() } else { muted() }),
                     )
-                    .fill(if hist_selected {
-                        accent().linear_multiply(0.18)
-                    } else {
-                        egui::Color32::TRANSPARENT
-                    })
+                    .fill(egui::Color32::TRANSPARENT)
                     .stroke(egui::Stroke::NONE)
                     .rounding(egui::Rounding::same(5.0))
                     .min_size(tab_size);
-                    if ui
+                    let hist_resp = ui
                         .add(hist_btn)
-                        .on_hover_cursor(egui::CursorIcon::PointingHand)
-                        .clicked()
-                    {
+                        .on_hover_cursor(egui::CursorIcon::PointingHand);
+                    if hist_selected {
+                        let y = hist_resp.rect.bottom() - 1.0;
+                        ui.painter().line_segment(
+                            [
+                                egui::pos2(hist_resp.rect.left() + 10.0, y),
+                                egui::pos2(hist_resp.rect.right() - 10.0, y),
+                            ],
+                            egui::Stroke::new(2.5, accent()),
+                        );
+                    }
+                    if hist_resp.clicked() {
                         self.sidebar_view = SidebarView::History;
                     }
                 });
@@ -228,10 +238,13 @@ impl ApiClient {
                     .add_sized(
                         [ui.available_width(), 32.0],
                         egui::Button::new(
-                            egui::RichText::new("➕  New Collection")
-                                .size(13.0)
-                                .color(egui::Color32::WHITE)
-                                .strong(),
+                            egui::RichText::new(format!(
+                                "{}  New Collection",
+                                egui_phosphor::regular::PLUS
+                            ))
+                            .size(13.0)
+                            .color(egui::Color32::WHITE)
+                            .strong(),
                         )
                         .fill(accent())
                         .rounding(egui::Rounding::same(8.0))
@@ -479,10 +492,14 @@ impl ApiClient {
                 });
             if ui
                 .add(
-                    egui::Button::new(egui::RichText::new("⚙").size(13.0).color(muted()))
-                        .min_size(egui::vec2(28.0, 26.0))
-                        .fill(egui::Color32::TRANSPARENT)
-                        .stroke(egui::Stroke::new(1.0, border())),
+                    egui::Button::new(
+                        egui::RichText::new(egui_phosphor::regular::GEAR)
+                            .size(13.0)
+                            .color(muted()),
+                    )
+                    .min_size(egui::vec2(28.0, 26.0))
+                    .fill(egui::Color32::TRANSPARENT)
+                    .stroke(egui::Stroke::new(1.0, border())),
                 )
                 .on_hover_cursor(egui::CursorIcon::PointingHand)
                 .on_hover_text("Manage environments")
@@ -968,7 +985,21 @@ impl ApiClient {
                 egui::pos2(header_rect.left() + 25.0, header_rect.top()),
                 egui::pos2(right_edge - 4.0, header_rect.bottom()),
             );
-            let mut child_ui = ui.new_child(egui::UiBuilder::new().max_rect(rename_rect));
+            let bg = if is_light() {
+                egui::Color32::from_rgb(248, 250, 253)
+            } else {
+                elevated()
+            };
+            ui.painter()
+                .rect_filled(rename_rect.expand(1.0), egui::Rounding::same(7.0), bg);
+            ui.painter().rect_stroke(
+                rename_rect.expand(1.0),
+                egui::Rounding::same(7.0),
+                egui::Stroke::new(1.2, accent()),
+            );
+            let mut child_ui = ui.new_child(
+                egui::UiBuilder::new().max_rect(rename_rect.shrink2(egui::vec2(6.0, 1.0))),
+            );
             child_ui.horizontal(|ui| {
                 let btn_size = egui::vec2(22.0, 22.0);
                 // Reserve space for the two action buttons, everything
@@ -977,7 +1008,9 @@ impl ApiClient {
                 let response = ui.add(
                     egui::TextEdit::singleline(&mut self.rename_folder_text)
                         .desired_width(edit_width)
-                        .font(egui::TextStyle::Body),
+                        .font(egui::TextStyle::Body)
+                        .text_color(text())
+                        .frame(false),
                 );
                 let (enter, escape) = ui.input(|i| {
                     (


### PR DESCRIPTION
## Summary
- align sidebar and response tab active states with underline/rail styling
- modernize OAuth2, extractor, and assertion form controls
- switch legacy modal CTAs/icons/status copy to theme-aware UI patterns
- ignore local SKILL.md handoff notes

## Tests
- cargo fmt
- cargo clippy --all-targets -- -D warnings
- cargo test